### PR TITLE
Support of pipe tables

### DIFF
--- a/src/FSharp.Markdown/Main.fs
+++ b/src/FSharp.Markdown/Main.fs
@@ -34,7 +34,7 @@ module private Utils  =
 /// uses an F# discriminated union type and so is best used from F#.
 type MarkdownDocument(paragraphs, links) =
   /// Returns a list of paragraphs in the document
-  member x.Paragraphs : MarkdownParagrphs = paragraphs
+  member x.Paragraphs : MarkdownParagraphs = paragraphs
   /// Returns a dictionary containing explicitly defined links
   member x.DefinedLinks : IDictionary<string, string * option<string>> = links
 


### PR DESCRIPTION
I've added support of pipe tables. Description: [github](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#wiki-tables), [pandoc](http://johnmacfarlane.net/pandoc/README.html#pipe-tables).

It transforms (orgtbl style where + is used instead of | in separator row is also supported)

```
| Markdown | Less      | Pretty                             |
|----------+:---------:+-----------------------------------:|
| *Still*  | `renders` | **nicely**                         |
| 1        | 2         | [Try F# 3.0](http://tryfsharp.org) |
```

into

```
<table>
<thead>
<tr class="header">
<th><p>Markdown</p></th>
<th align="center"><p>Less</p></th>
<th align="right"><p>Pretty</p></th>
</tr>
</thead>
<tbody>
<tr class="odd">
<td><p><em>Still</em></p></td>
<td align="center"><p><code>renders</code></p></td>
<td align="right"><p><strong>nicely</strong></p></td>
</tr>
<tr class="even">
<td><p>1</p></td>
<td align="center"><p>2</p></td>
<td align="right"><p><a href="http://tryfsharp.org">Try F# 3.0</a></p></td>
</tr>
</tbody>
</table>
```

I've added case to the ParagraphNested function to reconstruct table. But still not sure about the correctness (i've tested only the html generation).
