### PR TITLE
Literate: add 2nd include to match NuGet package layout

### DIFF
--- a/literate/literate.fsx
+++ b/literate/literate.fsx
@@ -14,6 +14,7 @@ and `FSharp.CodeFormat.dll` to colorize F# source & parse Markdown:
 namespace FSharp.Literate
 #if INTERACTIVE
 #I "../bin/"
+#I "../lib/net40/"
 #r "System.Web.dll"
 #r "FSharp.Markdown.dll"
 #r "FSharp.CodeFormat.dll"


### PR DESCRIPTION
literate.fsx currently expects the binaries in ../bin/. However, when using it directly from the NuGet package, the binaries are actually in ../lib/net40/.

Suggestion: I've added a second include directive so it works in both situations OOTB. Unfortunately it also causes an FS0211 search-dir not found warning in both (since in either case one of them does not actually exist). Maybe there's a better solution?
