### PR TITLE
Fix RecordFields and UnionCases not appearing in generated reference docs

### DIFF
--- a/misc/templates/reference/type.cshtml
+++ b/misc/templates/reference/type.cshtml
@@ -52,7 +52,7 @@
 
   @RenderPart("members", new {
     Header = "Record Fields",
-    TableHeader = "Record Fieldr",
+    TableHeader = "Record Field",
     Members = Model.Type.RecordFields
   })
 


### PR DESCRIPTION
In FSharp.Data I had to override `types.cshtml` to this (https://github.com/fsharp/FSharp.Data/blob/master/docs/tools/reference/type.cshtml) to be able to get the union cases working (see the output at https://ovatsus.github.com/FSharp.Data/reference/fsharp-data-json-jsonvalue.html), so I'm sending the exact same change to the default in this pull request.

I think it would make more sense to use `g.Members.Where(m => m.Kind == MemberKind.UnionCase)` instead of `Model.Type.UnionCases`, but for some reason it didn't work, so I left it like this. I'm not sure where categories came from so I wasn't able to test it in that scenario.

Record fields unfortunately still don't work (see http://blog.codebeside.org/FSharp.Data/reference/fsharp-data-runtime-structuraltypes-inferedproperty.html for example)

I haven't look into this with detail, but it seems you deleted this bit by accident when refactoring after merging @soloman817 (see https://github.com/tpetricek/FSharp.Formatting/commit/96f46d1c8621ce1d45109d83ca8cca04dbe4bf50#comments)
