### PR TITLE
example of //[snippet:...] usage

### DIFF
--- a/codeformat.html
+++ b/codeformat.html
@@ -222,8 +222,25 @@ to generate nice HTML output from an F# snippet. This is used, for example on
 </tr>
 </table>
 
-<p>If the input contains multiple snippets spearated using the <code>[snippet:...]</code> comment,
-then the formatter returns multiple HTML blocks. However, the generated tool tips
+<p>If the input contains multiple snippets spearated using the <code>//[snippet:...]</code> comment, e.g.:</p>
+<table class="pre"><tr><td class="lines"><pre class="fssnip">
+<span class="l">1: </span>
+
+<span class="l">23: </span>
+<span class="l">24: </span>
+
+</pre>
+</td>
+<td class="snippet"><pre class="fssnip"><span class="c">//[snippet:1]</span>
+...
+<span class="c">//[/snippet]</span>
+<span class="c">//[snippet:2]</span>
+...
+</pre>
+</td>
+</tr>
+</table>
+<p>then the formatter returns multiple HTML blocks. However, the generated tool tips
 are shared by all snippets (to save space) and so they are returned separately.</p>
 
           <div class="tip" id="fs1">namespace FSharp</div>


### PR DESCRIPTION
Make clear to use command with // style comment and not (\* or (***
