### PR TITLE
updated docs for commandline tool

### DIFF
--- a/docs/content/commandline.md
+++ b/docs/content/commandline.md
@@ -1,8 +1,8 @@
 ﻿F# Formatting: Command line tool
 ================================
 
-If you prefer to use F# Formatting tools via command line, you can use the 
-`FSharp.Formatting.CommandTool` package, which includes an executable `fsformatting.exe` 
+If you prefer to use F# Formatting tools via command line, you can use the
+`FSharp.Formatting.CommandTool` package, which includes an executable `fsformatting.exe`
 that gives you access to the most important functionality via a simple command line
 interface. This might be a good idea if you prefer to run F# Formatting as a separate
 process, e.g. for resource management reasons.
@@ -25,26 +25,80 @@ or download the [compiled binaries](https://github.com/tpetricek/FSharp.Formatti
 Using the tool
 --------------
 
-The documentation is coming soon!
+The tool option syntax is similar to git or other popular command line tools.
+The format of the command line interface is:
+
+    [lang=text]
+    fsformatting[.exe] [[command] [function] [options] || --help]
+
+In order to provide consistency across different shell environments, the command line tool appears to be case-insensitive by matching against lower case strings.
+
+The `[command]` directive maps to the corresponding library namespace:
+
+* `literate` - Selects namespace `FSharp.Literate`
+* `metadataFormat` - Selects namespace `FSharp.MetadataFormat`
+
+Currently, the command line tools exposes the functions `ProcessDirectory` of namespace `FSharp.Literate`
+and `Generate` of namespace `FSharp.MetadataFormat`.
+
+The `--help` option as single specifier displays the help message for all valid `[command] [function] [options]` combinations.
 
 Literate programming command
 ----------------------------
 
+`FSharp.Literate.ProcessDirectory`: Process a directory containing a mix of Markdown documents `*.md` and F# Script files `*.fsx`
+according to the concept of [Literate Programming](http://tpetricek.github.io/FSharp.Formatting/demo.html).
+
     [lang=text]
-    fsformatting.exe [command] [options]
+    fsformatting[.exe] literate --processDirectory [options]
 
-Options are
+Required options:
+* `--inputDirectory` - Input directory containing `*.fsx` and `*.md` files.
 
- - todo
- - todo
+Other Options:
+* `--templateFile` -  Template file for formatting.
+* `--outputDirectory` -  Output directory, defaults to input directory.
+* `--format` -  Output format either `latex` or `html`, defaults to `html`.
+* `--prefix` -  Prefix for formatting, defaults to `fs`.
+* `--compilerOptions` -  Compiler Options.
+* `--lineNumbers` -  Line number option, defaults to `true`.
+* `--references` -  Turn all indirect links into references, defaults to `false`.
+* `--replacements` -  A whitespace separated list of string pairs as text replacement patterns for the format template file.
+* `--includeSource` -  Include sourcecode in documentation, defaults to `false`.
+* `--layoutRoots` -  Search directory list for the Razor Engine.
+* `--help` -  Display the specific help message for `literate --processDirectory`.
+* `--waitForKey` -  Wait for key before exit.
+
+Example:
+
+    [lang=text]
+    fsformatting literate --processDirectory --templateFile template-project.html --format latex --replacements "page-author" "Tomas Petricek"
 
 Library documentation command
-----------------------------
+-----------------------------
+
+`FSharp.MetadataFormat.Generate`: Build the [library documentation](http://tpetricek.github.io/FSharp.Formatting/metadata.html) by scanning the metadata of the `*.dll` files of the package.
 
     [lang=text]
-    fsformatting.exe [command] [options]
+    fsformatting[.exe] metadataFormat --generate [options]
 
-Options are
+Required options:
+* `--dllFiles` -  List of `dll` input files.
+* `--outDir` -  Output directory.
+* `--layoutRoots` -  Search directory list for the Razor Engine templates.
 
- - todo
- - todo
+Other options:
+* `--parameters` -  Property settings for the Razor Engine.
+* `--namespaceTemplate` -  Namespace template file for formatting, defaults to `namespaces.cshtml`.
+* `--moduleTemplate` -  Module template file for formatting, defaults to `module.cshtml`.
+* `--typeTemplate` -  Type template file for formatting, defaults to `type.cshtml`.
+* `--xmlFile` -  Single XML file to use for all `dll` files, otherwise using `file.xml` for each `file.dll`.
+* `--sourceRepo` -  Source repository URL; silently ignored, if a source repository folder is not provided.
+* `--sourceFolder` -  Source repository folder; silently ignored, if a source repository URL is not provided.
+* `--help` -  Display the specific help message for `metadataFormat --generate`.
+* `--waitForKey` -  Wait for key before exit.
+
+Example:
+
+    [lang=text]
+    fsformatting metadataFormat --generate --dllFiles lib1.dll "lib 2.dll" --outDir "../api-docs" --layoutRoots templates


### PR DESCRIPTION
This version should be an acceptable first shot for the commandline tool doc.

Some findings, I´d like to share:
- There should be a cross reference to the API docs of FSharp.Formatting and the cli tool, but the API reference [does not exist](http://tpetricek.github.io/FSharp.Formatting/metadata.html#) per today.
- The commandline tool is outdated with respect to `FSharp.MetadataFormat.Generate`, as it does not implement the options `publicOnly`and `otherFlags`. Most likely easy to update this, `FAKE` should not be harmed by it, anyway.
- It seems to be a wrong decision to use the [Gsscoder library](https://github.com/gsscoder/commandline) for cli argument parsing as there exists `Microsoft.FSharp.Compiler.SourceCodeServices.InteractiveChecker` (I stepped over it [here](https://github.com/fbmnds/FSharp.Formatting/blob/master/src/FSharp.MetadataFormat/Main.fs#L679)).
