### PR TITLE
Changed TargetFrameworkVersion to v4.5 as v4.5.1 is not available on mono

### DIFF
--- a/src/FSharp.Formatting.CommandTool/FSharp.Formatting.CommandTool.fsproj
+++ b/src/FSharp.Formatting.CommandTool/FSharp.Formatting.CommandTool.fsproj
@@ -9,7 +9,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>FSharp.FormattingCLI</RootNamespace>
     <AssemblyName>fsformatting</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
     <Name>FSharp.FormattingCLI</Name>


### PR DESCRIPTION
This fixes #115
