### PR TITLE
Fix case sensitivity issue in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [ ! -f packages/FAKE/tools/Fake.exe ]; then
+if [ ! -f packages/FAKE/tools/FAKE.exe ]; then
   mono .nuget/NuGet.exe install FAKE -OutputDirectory packages -ExcludeVersion -Prerelease
 fi
 mono packages/FAKE/tools/FAKE.exe build.fsx $@


### PR DESCRIPTION
The script was testing for `Fake.exe` when the fake filename is
`FAKE.exe`.  This made the build script very slow as it would reinstall
fake every time.
