### PR TITLE
show types of union case arguments

### DIFF
--- a/src/FSharp.MetadataFormat/Main.fs
+++ b/src/FSharp.MetadataFormat/Main.fs
@@ -381,10 +381,17 @@ module ValueReader =
     *)
 
   let readUnionCase (ctx:ReadingContext) (case:FSharpUnionCase) =
-    let usage (maxLength:int) = case.Name
+    let fields = case.UnionCaseFields |> List.ofSeq |> List.map (fun field -> formatType field.FieldType)
+    let buildUsage maxLength fields =
+        let long = "(" + (fields |> String.concat ",") + ")"
+        match long.Length with
+        | x when x <= 2 -> ""
+        | x when x <= maxLength -> long
+        | _ -> "(...)"
+    let usage (maxLength:int) = case.Name + buildUsage (maxLength - case.Name.Length) fields
     let modifiers = List.empty
     let typeparams = List.empty
-    let signature = case.UnionCaseFields |> List.ofSeq |> List.map (fun field -> formatType field.FieldType) |> String.concat " * "
+    let signature = fields |> String.concat " * "
     let loc = defaultArg case.ImplementationLocation case.DeclarationLocation
     let location = formatSourceLocation ctx.SourceFolderRepository loc
     MemberOrValue.Create(usage, modifiers, typeparams, signature, location)


### PR DESCRIPTION
Currently I don't have F# 3.1 installed, so I can only implement showing the type of arguments.
Related to #112
