### PR TITLE
fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ env:
   global:
     - EnableNuGetPackageRestore=true
   matrix:
-    - MONO_VERSION="3.2.4"
-    
+    - MONO_VERSION="3.2.5"
+
 install:
   - wget "http://download.xamarin.com/MonoFrameworkMDK/Macx86/MonoFramework-MDK-${MONO_VERSION}.macos10.xamarin.x86.pkg"
   - sudo installer -pkg "MonoFramework-MDK-${MONO_VERSION}.macos10.xamarin.x86.pkg" -target /


### PR DESCRIPTION
fix #131 

run tests in isolation
use .net 4.0 when running tests ( was 3.5 )
use mono 3.2.5 on travis ( was 3.2.4 )

The problem was nunit-console running all tests, from different assemblies, on same process ( the default from command line )

I am working on pr to FAKE for  -process support on Nunit target.

Anyway, the build script use the prerelease version of FAKE instead of stable.
That is because some used feature not in stable or to help FAKE people? 
If not, it's usually best to use stable, otherwise every build you get two variables when build fails ( bug on commit or FAKE regression )
