### PR TITLE
fix comment parsing when whitespace

### DIFF
--- a/src/Common/StringParsing.fs
+++ b/src/Common/StringParsing.fs
@@ -106,7 +106,7 @@ module String =
       lines 
       |> Seq.filter (String.IsNullOrWhiteSpace >> not)
       |> Seq.map (fun line -> line |> Seq.takeWhile Char.IsWhiteSpace |> Seq.length)
-      |> Seq.min
+      |> fun xs -> if Seq.isEmpty xs then 0 else Seq.min xs
     lines 
     |> Seq.map (fun line -> 
         if String.IsNullOrWhiteSpace(line) then ""


### PR DESCRIPTION
Should fix an issue where method parsing fails whenever xml comments are whitespace-only.
