### PR TITLE
C# support (suggestion)

### DIFF
--- a/src/FSharp.MetadataFormat/Main.fs
+++ b/src/FSharp.MetadataFormat/Main.fs
@@ -565,6 +565,7 @@ module Reader =
 
   let getXmlDocSigForMember (memb:FSharpMemberFunctionOrValue) =
     let memberName = 
+      try
         let name = memb.CompiledName.Replace(".ctor", "#ctor")
         let typeGenericParameters =
             memb.EnclosingEntity.GenericParameters |> Seq.mapi (fun num par -> par.Name, sprintf "`%d" num)
@@ -599,6 +600,9 @@ module Reader =
                 "(" + System.String.Join(",", paramTypeList) + ")"
             else ""
         sprintf "%s%s%s" name typeargs paramList
+      with exn ->
+        Log.logf  "Error while building member-name for %s because: %s" memb.FullName exn.Message
+        memb.CompiledName
     match (memb.XmlDocSig, memb.EnclosingEntity.TryFullName) with
     | "",  None    -> ""
     | "", Some(n)  -> sprintf "%s:%s.%s" (getMemberXmlDocsSigPrefix memb)  n memberName


### PR DESCRIPTION
This is a suggestion on how to add C# support. 

While now C# assemblies will now be processed we still have the following problems:
- Methods/Constructors will not be shown in the final documentation page, we need support in FSharp.Compiler.Service (maybe we should have this pull request open until the FSharp.Compiler.Service is fixed, as it is not as usefull until this is fixed, if you want to use this you can use matthid/FSharp.Compiler.Service@c5dfd4dd488f6dcd1024b0ed2b564ce9d2d414fa)
- Exception when there are extension methods (#201)
- Obviously line references are not working

The other commits add support for Assembly information in a type (you can add something like: Defined in Assembly "Other.dll" to you type template), see https://github.com/matthid/RazorEngine/blob/develop/doc/templates/reference/type.cshtml#L32. Now the namespaces are sorted (when you have multiple assemblies).
