### PR TITLE
Very basic cache for RazorRender instances in FSharp.Literate, fixes 204.

### DIFF
--- a/src/FSharp.Literate/Formatting.fs
+++ b/src/FSharp.Literate/Formatting.fs
@@ -68,12 +68,15 @@ module Templating =
           html.Replace("{" + key + id + "}", value)) input
         result 
 
+  /// Very basic and simple caching mechanism for RazorRender instances.
+  let private razorCache = new System.Collections.Concurrent.ConcurrentDictionary<string, RazorRender>()
+
   /// Depending on the template file, use either Razor engine
   /// or simple Html engine with {replacements} to format the document
   let private generateFile contentTag parameters templateOpt output layoutRoots =
     match templateOpt with
     | Some (file:string) when file.EndsWith("cshtml", true, CultureInfo.InvariantCulture) -> 
-        let razor = RazorRender(layoutRoots, [], Path.GetFileNameWithoutExtension file)
+        let razor = razorCache.GetOrAdd(file, fun file -> RazorRender(layoutRoots, [], Path.GetFileNameWithoutExtension file))
         let props = [ "Properties", dict parameters ]
         let generated = razor.ProcessFile(props)
         File.WriteAllText(output, generated)      


### PR DESCRIPTION
It's actually a memory leak as well when used with a lot of different templates, but I think its fine for now as FSharp.Formatting is normally not used within a long running process :/.
