### PR TITLE
Slight improvement of support for C# code

### DIFF
--- a/tests/FSharp.MetadataFormat.Tests/Tests.fs
+++ b/tests/FSharp.MetadataFormat.Tests/Tests.fs
@@ -177,3 +177,26 @@ let ``MetadataFormat handles c# dlls`` () =
   #if INTERACTIVE
   System.Diagnostics.Process.Start(output)
   #endif
+
+[<Test>]
+let ``MetadataFormat processes C# types and includes xml comments in docs`` () =
+    let library = root @@ "files" @@ "CSharpFormat.dll"
+    let output = getOutputDir()
+    MetadataFormat.Generate
+        ( library, output, layoutRoots, info, libDirs = [root @@ "../../lib"])
+    let fileNames = Directory.GetFiles(output)
+    let files = dict [ for f in fileNames -> Path.GetFileName(f), File.ReadAllText(f) ]
+    files.["index.html"] |> should contain "CLikeFormat"
+    files.["index.html"] |> should contain "Provides a base class for formatting languages similar to C."
+
+[<Test>]
+let ``MetadataFormat processes C# properties on types and includes xml comments in docs`` () =
+    let library = root @@ "files" @@ "CSharpFormat.dll"
+    let output = getOutputDir()
+    MetadataFormat.Generate
+        ( library, output, layoutRoots, info, libDirs = [root @@ "../../lib"])
+    let fileNames = Directory.GetFiles(output)
+    let files = dict [ for f in fileNames -> Path.GetFileName(f), File.ReadAllText(f) ] 
+    
+    files.["manoli-utils-csharpformat-clikeformat.html"] |> should contain "CommentRegEx"
+    files.["manoli-utils-csharpformat-clikeformat.html"] |> should contain "Regular expression string to match single line and multi-line"


### PR DESCRIPTION
After fixing the c# crashing I found that Fsharp.Formatting really didn't add any xmldoc comments to the generated API docs (MetadataFormat).

After some poking around I found that FSC consistently returned and empty string when `xmlDocSig` was requested from types and members. 
I suppose such are to be expected as FSC is _F#_ specific, so I created a small workaround.

Unfortunately it is in no way complete, for instance it only seems to work with _Properties_ and _Types_.
FSC fails reporting any methods from analyzing C# assemblies. 

But, this is still an improvement I think (albeit a small and incomplete one..)
