### PR TITLE
Added support for "raw" special tag.

### DIFF
--- a/src/Common/AssemblyInfo.fs
+++ b/src/Common/AssemblyInfo.fs
@@ -4,10 +4,10 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("FSharp.Formatting")>]
 [<assembly: AssemblyProductAttribute("FSharp.Formatting")>]
 [<assembly: AssemblyDescriptionAttribute("A package of libraries for building great F# documentation, samples and blogs")>]
-[<assembly: AssemblyVersionAttribute("2.4.35")>]
-[<assembly: AssemblyFileVersionAttribute("2.4.35")>]
+[<assembly: AssemblyVersionAttribute("2.4.36")>]
+[<assembly: AssemblyFileVersionAttribute("2.4.36")>]
 [<assembly: AssemblyCopyrightAttribute("Apache 2.0 License")>]
 do ()
 
 module internal AssemblyVersionInformation =
-    let [<Literal>] Version = "2.4.35"
+    let [<Literal>] Version = "2.4.36"

--- a/src/FSharp.Literate/Document.fs
+++ b/src/FSharp.Literate/Document.fs
@@ -41,6 +41,8 @@ type LiterateParagraph =
   | FormattedCode of Line list
   /// Ordinary formatted code snippet in non-F# language (tagged with language code)
   | LanguageTaggedCode of string * string
+  /// Block simply emitted without any formatting equivalent to <pre> tag in html
+  | RawBlock of Line list
 
   interface MarkdownEmbedParagraphs with
     member x.Render() = 

--- a/src/FSharp.Literate/ParseScript.fs
+++ b/src/FSharp.Literate/ParseScript.fs
@@ -142,6 +142,9 @@ module internal ParseScript =
     | BlockCommand(Command "include-value" ref)::blocks -> 
         let p = EmbedParagraphs(ValueReference(ref))
         transformBlocks noEval (p::acc) defs blocks
+    | BlockCommand(Command "raw" _) ::BlockSnippet(snip):: blocks -> 
+        let p = EmbedParagraphs(RawBlock(snip))
+        transformBlocks noEval (p::acc) defs blocks
 
     // Parse commands in [foo=bar,zoo], followed by a source code snippet
     //  * hide - the snippet will not be shown

--- a/src/FSharp.Literate/Transformations.fs
+++ b/src/FSharp.Literate/Transformations.fs
@@ -307,6 +307,7 @@ module internal Transformations =
   let rec replaceSpecialCodes ctx (formatted:IDictionary<_, _>) = function
     | Matching.LiterateParagraph(special) -> 
         match special with
+        | RawBlock lines -> Some (InlineBlock (unparse lines))
         | LiterateCode(_, { Visibility = (HiddenCode | NamedCode _) }) -> None
         | FormattedCode lines 
         | LiterateCode(lines, _) -> Some (formatted.[Choice1Of2 lines])


### PR DESCRIPTION
This adds support for a `(*** raw ***)` command. This is effectively the equivalent of a <pre/> html tag, but for markdown.
