### PR TITLE
Fix a bug where we would use the wrong xml documentation file.

### DIFF
--- a/src/FSharp.MetadataFormat/Main.fs
+++ b/src/FSharp.MetadataFormat/Main.fs
@@ -877,7 +877,15 @@ type MetadataFormat =
           let xmlFileOpt =
             Directory.EnumerateFiles(Path.GetDirectoryName(xmlFile),
                                      Path.GetFileNameWithoutExtension(xmlFile) + ".*")
-            |> Seq.tryFind (fun f -> Path.GetExtension(f).Equals(".xml", StringComparison.CurrentCultureIgnoreCase))
+            |> Seq.tryFind (fun f -> 
+                Path.GetFileName(f).Equals(Path.GetFileName(xmlFile), StringComparison.CurrentCultureIgnoreCase))
+          let xmlFileOpt =
+            match xmlFileOpt with
+            | Some v -> Some v
+            | None ->
+              Directory.EnumerateFiles(Path.GetDirectoryName(xmlFile),
+                                       Path.GetFileNameWithoutExtension(xmlFile) + ".*")
+              |> Seq.tryFind (fun f -> Path.GetExtension(f).Equals(".xml", StringComparison.CurrentCultureIgnoreCase))
 
           match xmlFileOpt with
           | None -> raise <| FileNotFoundException(sprintf "Associated XML file '%s' was not found." xmlFile)


### PR DESCRIPTION
This can happen when multiple .xml files are in target directory.
For example when we have the following files in a directory:

```
Project.dll
Project.Hosts.Console.xml
Project.xml
```

It could happen that we use `Project.dll` with `Project.Hosts.Console.xml`.
To provide the old behavior I first try to find an exact match and then fall back to the old code (should I remove that?)
