### PR TITLE
Add default section when markup comment parsing is disabled.

### DIFF
--- a/src/FSharp.MetadataFormat/Main.fs
+++ b/src/FSharp.MetadataFormat/Main.fs
@@ -512,7 +512,7 @@ module Reader =
    // TODO: process param, returns tags, note that given that FSharp.Formatting infers the signature
    // via reflection this tags are not so important in F#
    let str = full.ToString()
-   Comment.Create(str, str, [])
+   Comment.Create(str, str, [KeyValuePair("<default>", str)])
 
   let readCommentAndCommands (ctx:ReadingContext) xmlSig = 
     match ctx.XmlMemberLookup(xmlSig) with 


### PR DESCRIPTION
This way the default template works unmodified when `markDownComments = false` in `MetadataFormat.Generate` (ie shows comments in the type page).
