### PR TITLE
Add assembly info to "Type" and "Module".

### DIFF
--- a/src/FSharp.MetadataFormat/Main.fs
+++ b/src/FSharp.MetadataFormat/Main.fs
@@ -912,7 +912,7 @@ type MetadataFormat =
         | false, _ -> namespaces.Add(ns.Name, (ns.Modules, ns.Types))
 
     let namespaces = [ for (KeyValue(name, (mods, typs))) in namespaces -> Namespace.Create(name, mods, typs) ]
-    let asm = AssemblyGroup.Create(name, List.map fst assemblies, namespaces)
+    let asm = AssemblyGroup.Create(name, List.map fst assemblies, namespaces |> List.sortBy (fun ns -> ns.Name))
         
     // Generate all the HTML stuff
     Log.logf "Starting razor engine"


### PR DESCRIPTION
This adds assembly information to the "Type" and "Module" types. 
This information can then be used (in solutions with multiple projects) to add information to the `type.cshtml` template ("Defined in Assembly 1").

Also the namespaces are now sorted before given to the template.
