### PR TITLE
Add new keyword "storage" to the "paket" code highlighter

### DIFF
--- a/src/CSharpFormat/PaketFormat.cs
+++ b/src/CSharpFormat/PaketFormat.cs
@@ -41,10 +41,10 @@ namespace Manoli.Utils.CSharpFormat
                 return "source nuget github gist git http group framework version_in_path content"
                     + " copy_local redirects import_targets references cache strategy lowest_matching NUGET"
                     + " specs remote File username password copy_content_to_output_dir GITHUB GROUP GIT HTTP"
-                    + " CopyToOutputDirectory";
+                    + " CopyToOutputDirectory storage";
             }
         }
-        
+
         /// <summary>
         /// Matches version numbers
         /// </summary>

--- a/tests/FSharp.Literate.Tests/Tests.fs
+++ b/tests/FSharp.Literate.Tests/Tests.fs
@@ -289,6 +289,7 @@ let ``Correctly handles Paket coloring`` () =
     lowest_matching: true
     source https://nuget.org/api/v2 // nuget.org
     cache //hive/dependencies
+    storage: none
 
     // NuGet packages
     nuget NUnit ~> 2.6.3
@@ -331,6 +332,7 @@ let ``Correctly handles Paket coloring`` () =
   html |> shouldContainText "<span class=\"k\">redirects</span>"
   html |> shouldContainText "<span class=\"k\">strategy</span>"
   html |> shouldContainText "<span class=\"k\">version_in_path</span>"
+  html |> shouldContainText "<span class=\"k\">storage</span>"
 
   html |> shouldNotContainText "<span class=\"k\">http</span>s"
   html |> shouldNotContainText ".<span class=\"k\">git</span>"


### PR DESCRIPTION
Fixes #449 
Just added the "storage" to the list of paket keywords and modified the current test.