### PR TITLE
WIP: Adds support for attributes on modules, types and members

### DIFF
--- a/FSharp.Formatting.sln
+++ b/FSharp.Formatting.sln
@@ -126,6 +126,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".paket", ".paket", "{DE45ED
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "FSharp.Formatting.TestHelpers", "FSharp.Formatting.TestHelpers\FSharp.Formatting.TestHelpers.fsproj", "{0B552F94-33FE-4037-9C17-1EB2A885F263}"
 EndProject
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "AttributesTestLib", "tests\FSharp.MetadataFormat.Tests\files\TestLib\AttributesTestLib.fsproj", "{B266D118-15AE-4BE6-809E-E9E30CE5C62F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -220,6 +222,10 @@ Global
 		{0B552F94-33FE-4037-9C17-1EB2A885F263}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0B552F94-33FE-4037-9C17-1EB2A885F263}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0B552F94-33FE-4037-9C17-1EB2A885F263}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B266D118-15AE-4BE6-809E-E9E30CE5C62F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B266D118-15AE-4BE6-809E-E9E30CE5C62F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B266D118-15AE-4BE6-809E-E9E30CE5C62F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B266D118-15AE-4BE6-809E-E9E30CE5C62F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -244,6 +250,7 @@ Global
 		{08029B28-A5EA-42DB-AB4E-9C6BA9EF9441} = {4AE0198D-EDE5-40B0-A5CD-FC7B6F891D94}
 		{98624699-1B2F-4636-A3F7-EC72343CB2FD} = {4AE0198D-EDE5-40B0-A5CD-FC7B6F891D94}
 		{0B552F94-33FE-4037-9C17-1EB2A885F263} = {8D44B659-E9F7-4CE4-B5DA-D37CDDCD2525}
+		{B266D118-15AE-4BE6-809E-E9E30CE5C62F} = {4AE0198D-EDE5-40B0-A5CD-FC7B6F891D94}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {76F121F8-70E0-49FB-9ADF-C7B660C0EB67}

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+## 3.0.0-beta11 (06, May, 2018)
+ - Added support for attributes on modules, types and members
+ - Updated razor templates to show attributes and added a warning for obsolete API
+
 ## 3.0.0-beta10 (08, April, 2018)
  - Upgrade FSharp.Compiler.Service to be compatible with FAKE 5
 

--- a/misc/templates/reference/module.cshtml
+++ b/misc/templates/reference/module.cshtml
@@ -33,10 +33,28 @@
 
 <h1>@Model.Module.Name</h1>
 <p>
+    @if (Model.Module.IsObsolete)
+    {
+        <div class="alert alert-warning">
+        <strong>WARNING: </strong> This API is obsolete
+        <p>@Html.Encode(@Model.Module.ObsoleteMessage)</p>
+        </div> 
+    }
   <span>Namespace: @Model.Namespace.Name</span><br />
   @if(Model.ParentModule.Exists())
   {
   <span>Parent Module: <a href="@(Model.ParentModule.Value.UrlName).html">@Model.ParentModule.Value.Name</a></span>
+  }
+  @if (Model.Module.Attributes.Any())
+  {
+      <span>
+          Attributes:<br />
+          @foreach (var attr in Model.Module.Attributes)
+          {
+                @Html.Encode(@attr.Format())<br />
+          }
+          
+      </span>
   }
 </p>
 <div class="xmldoc">

--- a/misc/templates/reference/part-members.cshtml
+++ b/misc/templates/reference/part-members.cshtml
@@ -21,9 +21,26 @@
             @if (!it.Details.TypeArguments.IsEmpty) {
               <strong>Type parameters:</strong> @it.Details.FormatTypeArguments
             }
+            @if (Enumerable.Any(it.Attributes))
+            {
+            <span>
+            <strong>Attributes:</strong><br />
+            @foreach (var attr in it.Attributes)
+            {
+                 @Html.Encode(@attr.Format())<br />
+            }
+          </span>
+            }
           </div>
         </td>
         <td class="xmldoc">
+          @if (it.IsObsolete)
+          {
+              <div class="alert alert-warning">
+              <strong>WARNING: </strong> This API is obsolete
+              <p>@Html.Encode(@it.ObsoleteMessage)</p>
+              </div> 
+          }
           @if (!String.IsNullOrEmpty(it.Details.FormatSourceLocation))
           {
             <a href="@it.Details.FormatSourceLocation" class="github-link">

--- a/misc/templates/reference/part-nested.cshtml
+++ b/misc/templates/reference/part-nested.cshtml
@@ -10,7 +10,16 @@
           <td class="type-name">
             <a href="@(it.UrlName).html">@it.Name</a>
           </td>
-          <td class="xmldoc">@it.Comment.Blurb</td>
+          <td class="xmldoc">
+          @if (it.IsObsolete)
+          {
+              <div class="alert alert-warning">
+              <strong>WARNING: </strong> This API is obsolete
+              <p>@Html.Encode(@it.ObsoleteMessage)</p>
+              </div> 
+          }
+          @it.Comment.Blurb
+          </td>
         </tr>
       }
     </tbody>
@@ -28,7 +37,16 @@
           <td class="module-name">
             <a href="@(it.UrlName).html">@it.Name</a>
           </td>
-          <td class="xmldoc">@it.Comment.Blurb</td>
+          <td class="xmldoc">
+          @if (it.IsObsolete)
+          {
+              <div class="alert alert-warning">
+              <strong>WARNING: </strong> This API is obsolete
+              <p>@Html.Encode(@it.ObsoleteMessage)</p>
+              </div> 
+          }
+          @it.Comment.Blurb
+          </td>
         </tr>
       }
     </tbody>

--- a/misc/templates/reference/type.cshtml
+++ b/misc/templates/reference/type.cshtml
@@ -1,111 +1,144 @@
 @using FSharp.MetadataFormat
 @{
-  Layout = "template";
-  Title = Model.Type.Name + " - " + Properties["project-name"];
+    Layout = "template";
+    Title = Model.Type.Name + " - " + Properties["project-name"];
 }
 
 @{
-  // Get all the members & comment for the type
-  var members = (IEnumerable<Member>)Model.Type.AllMembers;
-  var comment = (Comment)Model.Type.Comment;
-  
-  // Group all members by their category which is an inline annotation
-  // that can be added to members using special XML comment:
-  //
-  //     /// [category:Something]
-  //
-  // ...and can be used to categorize members in large modules or types
-  // (but if this is not used, then all members end up in just one category)
-  var byCategory = members
-    .GroupBy(m => m.Category)
-    .OrderBy(g => String.IsNullOrEmpty(g.Key) ? "ZZZ" : g.Key)
-    .Select((g, n) => new { 
-      Index = n, 
-      GroupKey = g.Key, 
-      Members = g.OrderBy(m => m.Kind == MemberKind.StaticParameter ? "" : m.Name), 
-      Name = String.IsNullOrEmpty(g.Key) ? "Other type members" : g.Key 
-    });
+    // Get all the members & comment for the type
+    var members = (IEnumerable<Member>)Model.Type.AllMembers;
+    var comment = (Comment)Model.Type.Comment;
+    var type = (FSharp.MetadataFormat.Type)Model.Type;
+    // Group all members by their category which is an inline annotation
+    // that can be added to members using special XML comment:
+    //
+    //     /// [category:Something]
+    //
+    // ...and can be used to categorize members in large modules or types
+    // (but if this is not used, then all members end up in just one category)
+    var byCategory = members
+.GroupBy(m => m.Category)
+.OrderBy(g => String.IsNullOrEmpty(g.Key) ? "ZZZ" : g.Key)
+.Select((g, n) => new
+{
+    Index = n,
+    GroupKey = g.Key,
+    Members = g.OrderBy(m => m.Kind == MemberKind.StaticParameter ? "" : m.Name),
+    Name = String.IsNullOrEmpty(g.Key) ? "Other type members" : g.Key
+});
+
 }
 
 <h1>@Model.Type.Name</h1>
 <p>
-  <span>Namespace: @Model.Namespace.Name</span><br />
-  @if(Model.HasParentModule)
-  {
-  <span>Parent Module: <a href="@(Model.ParentModule.Value.UrlName).html">@Model.ParentModule.Value.Name</a></span>
-  }
+
+    @if (Model.Type.IsObsolete)
+    {
+        <div class="alert alert-warning">
+        <strong>WARNING: </strong> This API is obsolete
+        <p>@Html.Encode(@Model.Type.ObsoleteMessage)</p>
+        </div> 
+    }
+    <span>Namespace: @Model.Namespace.Name</span><br />
+    @if (Model.HasParentModule)
+    {
+        <span>Parent Module: <a href="@(Model.ParentModule.Value.UrlName).html">@Model.ParentModule.Value.Name</a></span><br />
+    }
+    @if (type.Attributes.Any())
+    {
+        <span>
+            Attributes: <br />
+            @foreach (var attr in type.Attributes)
+            {
+                 @Html.Encode(@attr.Format())<br />
+            }
+            
+        </span>
+    }
 </p>
 <div class="xmldoc">
-  @foreach (var sec in comment.Sections) {
-    // XML comment for the type has multiple sections that can be labelled
-    // with categories (to give comment for an individual category). Here, 
-    // we print only those that belong to the <default> section.
-    if (!byCategory.Any(g => g.GroupKey == sec.Key)) {
-      if (sec.Key != "<default>") {
-        <h2>@sec.Key</h2>
-      }
-      @sec.Value
+    @foreach (var sec in comment.Sections)
+    {
+        // XML comment for the type has multiple sections that can be labelled
+        // with categories (to give comment for an individual category). Here,
+        // we print only those that belong to the <default> section.
+        if (!byCategory.Any(g => g.GroupKey == sec.Key))
+        {
+            if (sec.Key != "<default>")
+            {
+                <h2>@sec.Key</h2>
+            }
+            @sec.Value
+        }
     }
-  }
 </div>
 @if (byCategory.Count() > 1)
 {
-  <!-- If there is more than 1 category in the type, generate TOC -->
-  <h2>Table of contents</h2>
-  <ul>
-    @foreach (var g in byCategory)
-    {
-      <li><a href="@("#section" + g.Index.ToString())">@g.Name</a></li>
-    }
-  </ul>
+    <!-- If there is more than 1 category in the type, generate TOC -->
+    <h2>Table of contents</h2>
+    <ul>
+        @foreach (var g in byCategory)
+        {
+            <li><a href="@("#section" + g.Index.ToString())">@g.Name</a></li>
+        }
+    </ul>
 }
-@foreach (var g in byCategory) {
-  // Iterate over all the categories and print members. If there are more than one
-  // categories, print the category heading (as <h2>) and add XML comment from the type
-  // that is related to this specific category.
-  if (byCategory.Count() > 1) {
-    <h2>@g.Name<a name="@("section" + g.Index.ToString())">&#160;</a></h2>
-    var info = comment.Sections.FirstOrDefault(kvp => kvp.Key == g.GroupKey);
-    if (info.Key != null) {
-      <div class="xmldoc">
-        @info.Value
-      </div>
+@foreach (var g in byCategory)
+{
+    // Iterate over all the categories and print members. If there are more than one
+    // categories, print the category heading (as <h2>) and add XML comment from the type
+    // that is related to this specific category.
+    if (byCategory.Count() > 1)
+    {
+        <h2>@g.Name<a name="@("section" + g.Index.ToString())">&#160;</a></h2>
+        var info = comment.Sections.FirstOrDefault(kvp => kvp.Key == g.GroupKey);
+        if (info.Key != null)
+        {
+            <div class="xmldoc">
+                @info.Value
+            </div>
+        }
     }
-  }
 
-  @RenderPart("part-members", new {
-    Header = "Union Cases",
-    TableHeader = "Union Case",
-    Members = g.Members.Where(m => m.Kind == MemberKind.UnionCase)
-  })
+    @RenderPart("part-members", new
+    {
+        Header = "Union Cases",
+        TableHeader = "Union Case",
+        Members = g.Members.Where(m => m.Kind == MemberKind.UnionCase)
+    })
 
-  @RenderPart("part-members", new {
-    Header = "Record Fields",
-    TableHeader = "Record Field",
-    Members = g.Members.Where(m => m.Kind == MemberKind.RecordField)
-  })
-        
-  @RenderPart("part-members", new {
-    Header = "Static parameters",
-    TableHeader = "Static parameters",
-    Members = g.Members.Where(m => m.Kind == MemberKind.StaticParameter)
-  })
+    @RenderPart("part-members", new
+    {
+        Header = "Record Fields",
+        TableHeader = "Record Field",
+        Members = g.Members.Where(m => m.Kind == MemberKind.RecordField)
+    })
 
-  @RenderPart("part-members", new {
-    Header = "Constructors",
-    TableHeader = "Constructor",
-    Members = g.Members.Where(m => m.Kind == MemberKind.Constructor)
-  })
+    @RenderPart("part-members", new
+    {
+        Header = "Static parameters",
+        TableHeader = "Static parameters",
+        Members = g.Members.Where(m => m.Kind == MemberKind.StaticParameter)
+    })
 
-  @RenderPart("part-members", new {
-    Header = "Instance members",
-    TableHeader = "Instance member",
-    Members = g.Members.Where(m => m.Kind == MemberKind.InstanceMember)
-  })
+    @RenderPart("part-members", new
+    {
+        Header = "Constructors",
+        TableHeader = "Constructor",
+        Members = g.Members.Where(m => m.Kind == MemberKind.Constructor)
+    })
 
-  @RenderPart("part-members", new {
-    Header = "Static members",
-    TableHeader = "Static member",
-    Members = g.Members.Where(m => m.Kind == MemberKind.StaticMember)
-  })
+    @RenderPart("part-members", new
+    {
+        Header = "Instance members",
+        TableHeader = "Instance member",
+        Members = g.Members.Where(m => m.Kind == MemberKind.InstanceMember)
+    })
+
+    @RenderPart("part-members", new
+    {
+        Header = "Static members",
+        TableHeader = "Static member",
+        Members = g.Members.Where(m => m.Kind == MemberKind.StaticMember)
+    })
 }

--- a/tests/FSharp.CodeFormat.Tests/FSharp.CodeFormat.Tests.fsproj
+++ b/tests/FSharp.CodeFormat.Tests/FSharp.CodeFormat.Tests.fsproj
@@ -24,5 +24,8 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\FSharp.CodeFormat\FSharp.CodeFormat.fsproj" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/tests/FSharp.Literate.Tests/FSharp.Literate.Tests.fsproj
+++ b/tests/FSharp.Literate.Tests/FSharp.Literate.Tests.fsproj
@@ -42,5 +42,8 @@
     <ProjectReference Include="..\..\src\FSharp.Markdown\FSharp.Markdown.fsproj" />
     <ProjectReference Include="..\..\src\FSharp.MetadataFormat\FSharp.MetadataFormat.fsproj" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/tests/FSharp.Markdown.Tests/FSharp.Markdown.Tests.fsproj
+++ b/tests/FSharp.Markdown.Tests/FSharp.Markdown.Tests.fsproj
@@ -27,5 +27,8 @@
     <ProjectReference Include="..\..\src\FSharp.Formatting.Common\FSharp.Formatting.Common.fsproj" />
     <ProjectReference Include="..\..\src\FSharp.Markdown\FSharp.Markdown.fsproj" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/tests/FSharp.MetadataFormat.Tests/AttributeTests.fs
+++ b/tests/FSharp.MetadataFormat.Tests/AttributeTests.fs
@@ -1,0 +1,305 @@
+#if INTERACTIVE
+System.IO.Directory.SetCurrentDirectory __SOURCE_DIRECTORY__
+#I "../../bin"
+#r "FSharp.Formatting.Common.dll"
+#r "FSharp.MetadataFormat.dll"
+#r "FSharp.Compiler.Service.dll"
+#r "../../packages/test/NUnit/lib/net45/nunit.framework.dll"
+#r "../../packages/test/FsUnit/lib/net45/FsUnit.NUnit.dll"
+
+#else
+[<NUnit.Framework.TestFixture>]
+module FSharp.MetadataFormat.AttributeTests
+#endif
+
+open FsUnit
+open System.IO
+open NUnit.Framework
+open FSharp.MetadataFormat
+open FsUnitTyped
+open Microsoft.FSharp.Compiler.SourceCodeServices
+open NUnit.Framework.Internal
+open System
+
+// --------------------------------------------------------------------------------------
+// Run the metadata formatter on sample project
+// --------------------------------------------------------------------------------------
+
+let (</>) a b = Path.Combine(a, b)
+let fullpath = Path.GetFullPath
+let fullpaths = List.map fullpath
+
+let root = __SOURCE_DIRECTORY__ |> fullpath
+
+
+// NOTE - For these tests to run properly they require the output of all the metadata
+// test project to be directed to the directory below
+let testBin = __SOURCE_DIRECTORY__ </> "../bin" |> fullpath
+
+#if INTERACTIVE 
+;;
+printfn "\n-- Root - %s" root;;
+printfn "\n-- TestBin - %s" testBin;;
+#endif 
+
+do FSharp.Formatting.TestHelpers.enableLogging()
+let library = testBin </> "AttributesTestLib.dll"
+
+let findModule name (moduleInfos: ModuleInfo list)=
+    moduleInfos
+    |> List.map (fun m-> m.Module)
+    |> List.find (fun m-> m.Name = name)
+
+let findType name (typeInfos: TypeInfo list)=
+    typeInfos
+    |> List.map (fun t -> t.Type)
+    |> List.find (fun t-> t.Name = name)
+
+[<Test>]
+let ``MetadataFormat extracts Attribute on Module``() =
+  let modules = MetadataFormat.Generate(library, libDirs = [testBin]).ModuleInfos
+  let modul = modules |> findModule "SingleAttributeModule"
+  let attribute = modul.Attributes.Head
+  attribute.Name |> shouldEqual "ObsoleteAttribute"
+  attribute.FullName |> shouldEqual "System.ObsoleteAttribute"
+  attribute.ConstructorArguments |> shouldBeEmpty
+  attribute.NamedConstructorArguments |> shouldBeEmpty
+
+[<Test>]
+let ``MetadataFormat extracts multiple Attributes on Module``() =
+  let modules = MetadataFormat.Generate(library, libDirs = [testBin]).ModuleInfos
+  let modul = modules |> findModule "MultipleAttributesModule"
+  let attributes = modul.Attributes
+  attributes.Length |> shouldEqual 3
+
+[<Test>]
+let ``MetadataFormat extracts Attribute with argument``() =
+  let modules = MetadataFormat.Generate(library, libDirs = [testBin]).ModuleInfos
+  let modul = modules |> findModule "SingleAttributeWithArgumentModule"
+  let attribute = modul.Attributes.Head
+  attribute.Name |> shouldEqual "ObsoleteAttribute"
+  attribute.FullName |> shouldEqual "System.ObsoleteAttribute"
+  attribute.ConstructorArguments |> shouldContain (box "obsolete")
+  attribute.NamedConstructorArguments |> shouldBeEmpty
+
+
+[<Test>]
+let ``MetadataFormat extracts Attribute with named arguments``() =
+  let modules = MetadataFormat.Generate(library, libDirs = [testBin]).ModuleInfos
+  let modul = modules |> findModule "SingleAttributeWithNamedArgumentsModule"
+  let attribute = modul.Attributes.Head
+  attribute.Name |> shouldEqual "TestAttribute"
+  attribute.FullName |> shouldEqual "AttributeTestNamespace.TestAttribute"
+  attribute.ConstructorArguments |> shouldBeEmpty
+  
+  attribute.NamedConstructorArguments |>  shouldContain ("Int", box 1)
+  attribute.NamedConstructorArguments |>  shouldContain ("String", box "test")
+  let _,arrayArgument = attribute.NamedConstructorArguments |> Seq.find (fun (n,_)-> n="Array")
+  arrayArgument |>  shouldEqual (box [| box "1"; box "2"|])
+  ()  
+
+[<Test>]
+let ``MetadataFormat extracts Attribute on interface``() =
+  let typeInfos = MetadataFormat.Generate(library, libDirs = [testBin]).TypesInfos
+  let interface' = typeInfos |> findType "AttributeInterface"
+  let attribute = interface'.Attributes.Head
+  attribute.Name |> shouldEqual "TestAttribute"
+  attribute.FullName |> shouldEqual "AttributeTestNamespace.TestAttribute"
+
+[<Test>]
+let ``MetadataFormat extracts Attribute on class``() =
+  let typeInfos = MetadataFormat.Generate(library, libDirs = [testBin]).TypesInfos
+  let class' = typeInfos |> findType "AttributeClass"
+  let attribute = class'.Attributes.Head
+  attribute.Name |> shouldEqual "TestAttribute"
+  attribute.FullName |> shouldEqual "AttributeTestNamespace.TestAttribute"
+
+[<Test>]
+let ``MetadataFormat extracts Attribute on value in module``() =
+  let typeInfos = MetadataFormat.Generate(library, libDirs = [testBin]).ModuleInfos
+  let module' = typeInfos |> findModule "ContentTestModule"
+  let testValue = module'.ValuesAndFuncs |> Seq.find (fun v -> v.Name ="testValue")
+  let attribute = testValue.Attributes.Head
+  attribute.Name |> shouldEqual "TestAttribute"
+  attribute.FullName |> shouldEqual "AttributeTestNamespace.TestAttribute"
+
+[<Test>]
+let ``MetadataFormat extracts Attribute on function in module``() =
+  let typeInfos = MetadataFormat.Generate(library, libDirs = [testBin]).ModuleInfos
+  let module' = typeInfos |> findModule "ContentTestModule"
+  let testFunction = module'.ValuesAndFuncs |> Seq.find (fun v -> v.Name ="testFunction")
+  let attribute = testFunction.Attributes.Head
+  attribute.Name |> shouldEqual "TestAttribute"
+  attribute.FullName |> shouldEqual "AttributeTestNamespace.TestAttribute"
+
+[<Test>]
+let ``MetadataFormat extracts Attribute on instance member in class``() =
+  let typeInfos = MetadataFormat.Generate(library, libDirs = [testBin]).TypesInfos
+  let class' = typeInfos |> findType "AttributeClass"
+  let testMember = class'.InstanceMembers |> Seq.find (fun v -> v.Name ="TestMember")
+  let attribute = testMember.Attributes.Head
+  attribute.Name |> shouldEqual "TestAttribute"
+  attribute.FullName |> shouldEqual "AttributeTestNamespace.TestAttribute"
+
+[<Test>]
+let ``MetadataFormat extracts Attribute on class constructor``() =
+  let typeInfos = MetadataFormat.Generate(library, libDirs = [testBin]).TypesInfos
+  let class' = typeInfos |> findType "AttributeClass"
+  let ctor = class'.Constructors |> Seq.find (fun v -> v.Details.Signature ="i:int -> AttributeClass")
+  let attribute = ctor.Attributes.Head
+  attribute.Name |> shouldEqual "TestAttribute"
+  attribute.FullName |> shouldEqual "AttributeTestNamespace.TestAttribute"
+  attribute.NamedConstructorArguments |>  shouldContain ("String", box "ctor")
+
+[<Test>]
+let ``MetadataFormat extracts Attribute on static member in class``() =
+  let typeInfos = MetadataFormat.Generate(library, libDirs = [testBin]).TypesInfos
+  let class' = typeInfos |> findType "AttributeClass"
+  let staticMember = class'.StaticMembers |> Seq.find (fun v -> v.Name ="TestStaticMember")
+  let attribute = staticMember.Attributes.Head
+  attribute.Name |> shouldEqual "TestAttribute"
+  attribute.FullName |> shouldEqual "AttributeTestNamespace.TestAttribute"
+
+[<Test>]
+let ``MetadataFormat extracts Attribute on union case``() =
+  let typeInfos = MetadataFormat.Generate(library, libDirs = [testBin]).TypesInfos
+  let union = typeInfos |> findType "AttributeUnion"
+  let case = union.UnionCases |> Seq.find (fun v -> v.Name ="TestCase")
+  let attribute = case.Attributes.Head
+  attribute.Name |> shouldEqual "TestAttribute"
+  attribute.FullName |> shouldEqual "AttributeTestNamespace.TestAttribute"
+  attribute.NamedConstructorArguments |>  shouldContain ("String", box "union")
+
+[<Test>]
+let ``MetadataFormat extracts Attribute on record field``() =
+  let typeInfos = MetadataFormat.Generate(library, libDirs = [testBin]).TypesInfos
+  let union = typeInfos |> findType "AttributeRecord"
+  let case = union.RecordFields |> Seq.find (fun v -> v.Name ="TestField")
+  let attribute = case.Attributes.Head
+  attribute.Name |> shouldEqual "TestAttribute"
+  attribute.FullName |> shouldEqual "AttributeTestNamespace.TestAttribute"
+  attribute.NamedConstructorArguments |>  shouldContain ("String", box "record")
+
+[<Test>]
+let ``MetadataFormat formats attribute without arguments``() =
+  let moduleInfos = MetadataFormat.Generate(library, libDirs = [testBin]).ModuleInfos
+  let module' = moduleInfos |> findModule "FormatTestModule"
+  let value = module'.ValuesAndFuncs |> Seq.find (fun v -> v.Name ="noArguments")
+  let attribute = value.Attributes.Head
+  attribute.Name |> shouldEqual "TestAttribute"
+  attribute.FullName |> shouldEqual "AttributeTestNamespace.TestAttribute"
+  attribute.Format() |> shouldEqual "[<Test>]"
+
+[<Test>]
+let ``MetadataFormat formats attribute with single int argument``() =
+  let moduleInfos = MetadataFormat.Generate(library, libDirs = [testBin]).ModuleInfos
+  let module' = moduleInfos |> findModule "FormatTestModule"
+  let value = module'.ValuesAndFuncs |> Seq.find (fun v -> v.Name ="singleIntArgument")
+  let attribute = value.Attributes.Head
+  attribute.Name |> shouldEqual "IntTestAttribute"
+  attribute.FullName |> shouldEqual "AttributeTestNamespace.IntTestAttribute"
+  attribute.Format() |> shouldEqual "[<IntTest(1)>]"
+
+[<Test>]
+let ``MetadataFormat formats attribute with single string argument``() =
+  let moduleInfos = MetadataFormat.Generate(library, libDirs = [testBin]).ModuleInfos
+  let module' = moduleInfos |> findModule "FormatTestModule"
+  let value = module'.ValuesAndFuncs |> Seq.find (fun v -> v.Name ="singleStringArgument")
+  let attribute = value.Attributes.Head
+  attribute.Name |> shouldEqual "StringTestAttribute"
+  attribute.FullName |> shouldEqual "AttributeTestNamespace.StringTestAttribute"
+  attribute.Format() |> shouldEqual """[<StringTest("test")>]"""
+
+[<Test>]
+let ``MetadataFormat formats attribute with single bool argument``() =
+  let moduleInfos = MetadataFormat.Generate(library, libDirs = [testBin]).ModuleInfos
+  let module' = moduleInfos |> findModule "FormatTestModule"
+  let value = module'.ValuesAndFuncs |> Seq.find (fun v -> v.Name ="singleBoolArgument")
+  let attribute = value.Attributes.Head
+  attribute.Name |> shouldEqual "BoolTestAttribute"
+  attribute.FullName |> shouldEqual "AttributeTestNamespace.BoolTestAttribute"
+  attribute.Format() |> shouldEqual "[<BoolTest(true)>]"
+
+
+[<Test>]
+let ``MetadataFormat formats attribute with single array argument``() =
+  let moduleInfos = MetadataFormat.Generate(library, libDirs = [testBin]).ModuleInfos
+  let module' = moduleInfos |> findModule "FormatTestModule"
+  let value = module'.ValuesAndFuncs |> Seq.find (fun v -> v.Name ="singleArrayArgument")
+  let attribute = value.Attributes.Head
+  attribute.Name |> shouldEqual "ArrayTestAttribute"
+  attribute.FullName |> shouldEqual "AttributeTestNamespace.ArrayTestAttribute"
+  attribute.Format() |> shouldEqual """[<ArrayTest([|"test1"; "test2"|])>]"""
+
+[<Test>]
+let ``MetadataFormat formats attribute with multiple arguments``() =
+  let moduleInfos = MetadataFormat.Generate(library, libDirs = [testBin]).ModuleInfos
+  let module' = moduleInfos |> findModule "FormatTestModule"
+  let value = module'.ValuesAndFuncs |> Seq.find (fun v -> v.Name ="multipleArguments")
+  let attribute = value.Attributes.Head
+  attribute.Name |> shouldEqual "MultipleTestAttribute"
+  attribute.FullName |> shouldEqual "AttributeTestNamespace.MultipleTestAttribute"
+  attribute.Format() |> shouldEqual """[<MultipleTest("test", 1, [|1; 2|])>]"""
+
+[<Test>]
+let ``MetadataFormat formats attribute with multiple named arguments``() =
+  let moduleInfos = MetadataFormat.Generate(library, libDirs = [testBin]).ModuleInfos
+  let module' = moduleInfos |> findModule "FormatTestModule"
+  let value = module'.ValuesAndFuncs |> Seq.find (fun v -> v.Name ="multipleNamedArguments")
+  let attribute = value.Attributes.Head
+  attribute.Name |> shouldEqual "TestAttribute"
+  attribute.FullName |> shouldEqual "AttributeTestNamespace.TestAttribute"
+  attribute.Format() |> shouldEqual """[<Test(Int = 1, String = "test", Array = [|"1"; "2"|])>]"""
+
+[<Test>]
+let ``MetadataFormat formats attribute with name and suffix``() =
+  let moduleInfos = MetadataFormat.Generate(library, libDirs = [testBin]).ModuleInfos
+  let module' = moduleInfos |> findModule "FormatTestModule"
+  let value = module'.ValuesAndFuncs |> Seq.find (fun v -> v.Name ="singleBoolArgument")
+  let attribute = value.Attributes.Head
+  attribute.Name |> shouldEqual "BoolTestAttribute"
+  attribute.FullName |> shouldEqual "AttributeTestNamespace.BoolTestAttribute"
+  attribute.FormatLongForm() |> shouldEqual "[<BoolTestAttribute(true)>]"
+[<Test>]
+let ``MetadataFormat formats attribute with fullName``() =
+  let moduleInfos = MetadataFormat.Generate(library, libDirs = [testBin]).ModuleInfos
+  let module' = moduleInfos |> findModule "FormatTestModule"
+  let value = module'.ValuesAndFuncs |> Seq.find (fun v -> v.Name ="singleBoolArgument")
+  let attribute = value.Attributes.Head
+  attribute.Name |> shouldEqual "BoolTestAttribute"
+  attribute.FullName |> shouldEqual "AttributeTestNamespace.BoolTestAttribute"
+  attribute.FormatFullName() |> shouldEqual "[<AttributeTestNamespace.BoolTest(true)>]"
+
+[<Test>]
+let ``MetadataFormat formats attribute with fullName and suffix``() =
+  let moduleInfos = MetadataFormat.Generate(library, libDirs = [testBin]).ModuleInfos
+  let module' = moduleInfos |> findModule "FormatTestModule"
+  let value = module'.ValuesAndFuncs |> Seq.find (fun v -> v.Name ="singleBoolArgument")
+  let attribute = value.Attributes.Head
+  attribute.Name |> shouldEqual "BoolTestAttribute"
+  attribute.FullName |> shouldEqual "AttributeTestNamespace.BoolTestAttribute"
+  attribute.FormatFullNameLongForm() |> shouldEqual "[<AttributeTestNamespace.BoolTestAttribute(true)>]"
+
+[<Test>]
+let ``MetadataFormat IsObsolete returns true on obsolete attribute``() =
+  let moduleInfos = MetadataFormat.Generate(library, libDirs = [testBin]).ModuleInfos
+  let module' = moduleInfos |> findModule "ObsoleteTestModule"
+  let noMessage = module'.ValuesAndFuncs |> Seq.find (fun v -> v.Name ="noMessage")
+  noMessage.IsObsolete |> shouldEqual true
+  noMessage.ObsoleteMessage |> shouldEqual ""
+
+[<Test>]
+let ``MetadataFormat IsObsolete returns true on obsolete attribute and finds obsolete message``() =
+  let moduleInfos = MetadataFormat.Generate(library, libDirs = [testBin]).ModuleInfos
+  let module' = moduleInfos |> findModule "ObsoleteTestModule"
+  let withMessage = module'.ValuesAndFuncs |> Seq.find (fun v -> v.Name ="withMessage")
+  withMessage.IsObsolete |> shouldEqual true
+  withMessage.ObsoleteMessage |> shouldEqual "obsolete"
+
+[<Test>]
+let ``MetadataFormat IsObsolete returns false on not obsolete attribute and finds no obsolete message``() =
+  let moduleInfos = MetadataFormat.Generate(library, libDirs = [testBin]).ModuleInfos
+  let module' = moduleInfos |> findModule "ObsoleteTestModule"
+  let notObsolete = module'.ValuesAndFuncs |> Seq.find (fun v -> v.Name ="notObsolete")
+  notObsolete.IsObsolete |> shouldEqual false
+  notObsolete.ObsoleteMessage |> shouldEqual ""

--- a/tests/FSharp.MetadataFormat.Tests/FSharp.MetadataFormat.Tests.fsproj
+++ b/tests/FSharp.MetadataFormat.Tests/FSharp.MetadataFormat.Tests.fsproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="AttributeTests.fs" />
     <None Include="paket.references" />
     <Compile Include="Tests.fs" />
     <Content Include="app.config" />
@@ -30,6 +31,10 @@
     <ProjectReference Include="$(SolutionDir)\src\FSharp.Formatting.Razor\FSharp.Formatting.Razor.fsproj" />
     <ProjectReference Include="$(SolutionDir)\src\FSharp.Literate\FSharp.Literate.fsproj" />
     <ProjectReference Include="$(SolutionDir)\src\FSharp.MetadataFormat\FSharp.MetadataFormat.fsproj" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/tests/FSharp.MetadataFormat.Tests/files/TestLib/Attributes.fs
+++ b/tests/FSharp.MetadataFormat.Tests/files/TestLib/Attributes.fs
@@ -1,0 +1,98 @@
+namespace AttributeTestNamespace
+    open System
+    type TestAttribute(?int:int,?string:string, ?array:string array) =     
+        inherit Attribute()
+        new() = TestAttribute()
+        member val String = defaultArg string "" with get, set
+        member val Int = defaultArg int 0 with get, set
+        member val Array = defaultArg array [||] with get, set   
+      
+    type IntTestAttribute(int:int) =     
+        inherit Attribute()
+
+    type BoolTestAttribute(bool:bool) =     
+        inherit Attribute()
+
+    type StringTestAttribute(string:string) =     
+        inherit Attribute()
+
+    type ArrayTestAttribute(array:string array) =     
+        inherit Attribute()
+    type MultipleTestAttribute(string:string,int:int,array:int array) =     
+        inherit Attribute()  
+
+    [<Obsolete>]
+    module SingleAttributeModule = 
+        let x = 1
+
+    [<Obsolete("obsolete")>]
+    module SingleAttributeWithArgumentModule =
+        let x = 1
+
+    [<TestAttribute(Int = 1, String = "test", Array = [|"1"; "2"|])>]
+    module SingleAttributeWithNamedArgumentsModule =
+        let x = 1
+
+    [<TestAttribute>]
+    [<Obsolete>]
+    [<AutoOpen>]
+    module MultipleAttributesModule = 
+        let x = 1
+
+    [<TestAttribute>]
+    type AttributeInterface =
+        [<TestAttribute>]
+        abstract member TestMember: int -> int -> int
+
+    [<TestAttribute>]
+    type AttributeClass() =
+        [<TestAttribute(String="ctor")>]
+        new(i:int) = AttributeClass()
+        [<TestAttribute>]
+        member __.TestMember = 1
+        [<TestAttribute>]
+        static member TestStaticMember = 2
+    type AttributeRecord =
+        {
+            [<TestAttribute(String="record")>]
+            TestField:int }
+
+    type AttributeUnion =
+        | [<TestAttribute(String="union")>] TestCase
+        | TestCase2 of int
+
+    module ContentTestModule =
+        [<TestAttribute>]
+        let testValue = 1
+
+        [<TestAttribute>]
+        let testFunction a = a + 1
+
+    
+    module FormatTestModule =
+        [<TestAttribute>]
+        let noArguments = 0
+        [<IntTestAttribute(1)>]
+        let singleIntArgument = 0
+        [<StringTestAttribute("test")>]
+        let singleStringArgument = 0
+        [<ArrayTestAttribute([|"test1";"test2"|])>]
+        let singleArrayArgument = 0
+        [<BoolTestAttribute(true)>]
+        let singleBoolArgument = 0
+        [<MultipleTestAttribute("test",1,[|1;2|])>]
+        let multipleArguments = 0
+        [<TestAttribute(Int = 1, String = "test", Array = [|"1"; "2"|])>]
+        let multipleNamedArguments = 0
+        [<TestAttribute>]
+        [<IntTestAttribute(1)>]
+        [<StringTestAttribute("test")>]
+        let multipleAttributes = 0
+
+    module ObsoleteTestModule =
+        [<Obsolete>]
+        let noMessage = 0
+        [<Obsolete("obsolete")>]
+        let withMessage = 0
+        
+        let notObsolete = 0

--- a/tests/FSharp.MetadataFormat.Tests/files/TestLib/AttributesTestLib.fsproj
+++ b/tests/FSharp.MetadataFormat.Tests/files/TestLib/AttributesTestLib.fsproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+  <PropertyGroup>
+    <TargetFramework>net461</TargetFramework>
+    <SolutionDir>..\..\..\..\</SolutionDir>
+     <OutputType>Library</OutputType>
+    <DocumentationFile>$(SolutionDir)\tests\bin\$(AssemblyName).xml</DocumentationFile>
+    <OutputPath>$(SolutionDir)\tests\bin</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>    
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <Compile Include="Attributes.fs" />
+    <None Include="paket.references" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Numerics" />
+  </ItemGroup>
+  
+  <Import Project="..\..\..\..\.paket\Paket.Restore.targets" />
+</Project>

--- a/tests/FSharp.MetadataFormat.Tests/files/TestLib/TestLib.sln
+++ b/tests/FSharp.MetadataFormat.Tests/files/TestLib/TestLib.sln
@@ -1,9 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "TestLib1", "TestLib1.fsproj", "{AD192375-D530-40FB-A4E9-380C74CBB771}"
+# Visual Studio 15
+VisualStudioVersion = 15.0.27428.2043
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "TestLib1", "TestLib1.fsproj", "{AD192375-D530-40FB-A4E9-380C74CBB771}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "TestLib2", "TestLib2.fsproj", "{768FD0E0-5CF7-4AF0-98C9-4B848F9AFB62}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "TestLib2", "TestLib2.fsproj", "{768FD0E0-5CF7-4AF0-98C9-4B848F9AFB62}"
+EndProject
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "AttributesTestLib", "AttributesTestLib.fsproj", "{B2CB4ACB-26B8-4205-A23F-1058663052D3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -19,8 +23,15 @@ Global
 		{768FD0E0-5CF7-4AF0-98C9-4B848F9AFB62}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{768FD0E0-5CF7-4AF0-98C9-4B848F9AFB62}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{768FD0E0-5CF7-4AF0-98C9-4B848F9AFB62}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B2CB4ACB-26B8-4205-A23F-1058663052D3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2CB4ACB-26B8-4205-A23F-1058663052D3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2CB4ACB-26B8-4205-A23F-1058663052D3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2CB4ACB-26B8-4205-A23F-1058663052D3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {2A3F117A-B51A-48F2-B70B-184A09FE54EE}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Hi,
i have added support for attributes declared on types, members and modules.
There are also some functions to support the System.ObsoleteAttribute so it is easier to mark stuff as obsolete in documentation.

There is some stuff i am not quite sure about:

* As of now i do not add attributes to function parameters etc. That would probably not be too hard in general, but MemberOrValue.TypeArguments is just a string list right now, so its not really compatible.
* I have also not modified any templates yet. There are functions to format and an attribute/ multiple attributes, but i did not want to break all the existing templates. I am not sure whats the right approach here.
* If there are any plans to add attributes into the types list of a namespace/module, there might be some naming conflicts later on. But i am not sure if that is too important.
* I added the attributes for members right on the Member type and not on MemberOrValue. I am not sure what u prefer here.

Some side notes:
* the editorconfig enforces 4 spaces but alot of the files use 2. That makes it kinda hard to work with ;)
* is it just me or does the intellisense not work in vscode? I had to use vs. Not sure what i am doing wrong here :(