### PR TITLE
proper formatting of the usage

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+## 3.0.0-beta12 (29, July, 2018)
+ - Fix usage formatting - https://github.com/fsprojects/FSharp.Formatting/issues/472
+
 ## 3.0.0-beta11 (06, May, 2018)
  - Added support for attributes on modules, types and members
  - Updated razor templates to show attributes and added a warning for obsolete API

--- a/src/Common/AssemblyInfo.cs
+++ b/src/Common/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Reflection;
 [assembly: AssemblyDescriptionAttribute("A package of libraries for building great F# documentation, samples and blogs")]
 [assembly: AssemblyVersionAttribute("3.0.0")]
 [assembly: AssemblyFileVersionAttribute("3.0.0")]
-[assembly: AssemblyInformationalVersionAttribute("3.0.0-beta10")]
+[assembly: AssemblyInformationalVersionAttribute("3.0.0-beta11")]
 [assembly: AssemblyCopyrightAttribute("Apache 2.0 License")]
 namespace System {
     internal static class AssemblyVersionInformation {
@@ -13,7 +13,7 @@ namespace System {
         internal const System.String AssemblyDescription = "A package of libraries for building great F# documentation, samples and blogs";
         internal const System.String AssemblyVersion = "3.0.0";
         internal const System.String AssemblyFileVersion = "3.0.0";
-        internal const System.String AssemblyInformationalVersion = "3.0.0-beta10";
+        internal const System.String AssemblyInformationalVersion = "3.0.0-beta11";
         internal const System.String AssemblyCopyright = "Apache 2.0 License";
     }
 }

--- a/src/Common/AssemblyInfo.fs
+++ b/src/Common/AssemblyInfo.fs
@@ -6,7 +6,7 @@ open System.Reflection
 [<assembly: AssemblyDescriptionAttribute("A package of libraries for building great F# documentation, samples and blogs")>]
 [<assembly: AssemblyVersionAttribute("3.0.0")>]
 [<assembly: AssemblyFileVersionAttribute("3.0.0")>]
-[<assembly: AssemblyInformationalVersionAttribute("3.0.0-beta10")>]
+[<assembly: AssemblyInformationalVersionAttribute("3.0.0-beta11")>]
 [<assembly: AssemblyCopyrightAttribute("Apache 2.0 License")>]
 do ()
 
@@ -15,5 +15,5 @@ module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyDescription = "A package of libraries for building great F# documentation, samples and blogs"
     let [<Literal>] AssemblyVersion = "3.0.0"
     let [<Literal>] AssemblyFileVersion = "3.0.0"
-    let [<Literal>] AssemblyInformationalVersion = "3.0.0-beta10"
+    let [<Literal>] AssemblyInformationalVersion = "3.0.0-beta11"
     let [<Literal>] AssemblyCopyright = "Apache 2.0 License"

--- a/tests/FSharp.MetadataFormat.Tests/Tests.fs
+++ b/tests/FSharp.MetadataFormat.Tests/Tests.fs
@@ -36,11 +36,11 @@ let root = __SOURCE_DIRECTORY__ |> fullpath
 // test project to be directed to the directory below
 let testBin = __SOURCE_DIRECTORY__ </> "../bin" |> fullpath
 
-#if INTERACTIVE 
+#if INTERACTIVE
 ;;
 printfn "\n-- Root - %s" root;;
 printfn "\n-- TestBin - %s" testBin;;
-#endif 
+#endif
 
 let getOutputDir()  =
   let tempFile = Path.GetTempFileName()
@@ -75,9 +75,9 @@ let generate (libraries:string list) useMarkdown =
     with e ->
         printfn "Failed to Generate Metadata -\n%s\n\n%s\n" e.Message e.StackTrace
         System.AppDomain.CurrentDomain.GetAssemblies ()
-        |> Seq.iter (fun x -> 
+        |> Seq.iter (fun x ->
             try sprintf "%s\n - %s" x.FullName x.Location |> System.Console.WriteLine
-            with e -> 
+            with e ->
                 sprintf "\nError On - %A\n -- %s\n"  x e.Message |> System.Console.WriteLine
         )
         reraise ()
@@ -152,11 +152,20 @@ let ``MetadataFormat works on two sample F# assemblies``() =
   files.["fslib-class.html"] |> shouldContainText "<strong>Signature:</strong> unit -&gt; Class"
 
   // Check that properties are correctly generated (#114)
-  files.["fslib-class.html"] |> removeWhiteSpace |> shouldNotContainText ">Member(arg1)<"
-  files.["fslib-class.html"] |> removeWhiteSpace |> shouldNotContainText ">Member()<"
-  files.["fslib-class.html"] |> removeWhiteSpace |> shouldContainText ">Member<"
+  files.["fslib-class.html"] |> removeWhiteSpace |> shouldNotContainText ">x.Member(arg1)<"
+  files.["fslib-class.html"] |> removeWhiteSpace |> shouldNotContainText ">x.Member()<"
+  files.["fslib-class.html"] |> removeWhiteSpace |> shouldContainText ">x.Member<"
   files.["fslib-class.html"] |> shouldNotContainText "<strong>Signature:</strong> unit -&gt; int"
   files.["fslib-class.html"] |> shouldContainText "<strong>Signature:</strong> int"
+
+  // Check that formatting is correct
+  files.["fslib-test_issue472_r.html"] |> shouldContainText "Test_Issue472_R.fmultipleargs x y"
+  files.["fslib-test_issue472_r.html"] |> shouldContainText "Test_Issue472_R.ftupled(x, y)"
+  files.["fslib-test_issue472.html"] |> shouldContainText "fmultipleargs x y"
+  files.["fslib-test_issue472.html"] |> shouldContainText "ftupled(x, y)"
+  files.["fslib-test_issue472_t.html"] |> shouldContainText "x.MultArg(arg1, arg2)"
+  files.["fslib-test_issue472_t.html"] |> shouldContainText "x.MultArgTupled(arg)"
+  files.["fslib-test_issue472_t.html"] |> shouldContainText "x.MultPartial arg1 arg2"
 
   //#if INTERACTIVE
   //System.Diagnostics.Process.Start(output)
@@ -388,7 +397,7 @@ let ``MetadataFormat process XML comments in two sample F# assemblies``() =
 let ``MetadataFormat highlights code snippets in Markdown comments``() =
   let library = testBin </> "TestLib1.dll" |> fullpath
   //RazorMetadataFormat.Generate([library], output, layoutRoots, info, libDirs = [root </> "../../lib"], markDownComments = true)
-  
+
   let files = generate [library] true
 
   files.["fslib-myclass.html"] |> shouldContainText """<span class="k">let</span>"""
@@ -400,7 +409,7 @@ let ``MetadataFormat handles c# dlls`` () =
   let library = testBin </> "CSharpFormat.dll" |> fullpath
   //RazorMetadataFormat.Generate
   //  ( library, output, layoutRoots, info, libDirs = [root </> "../../lib"; root </> "../../bin"])
-  
+
   let files = (generate [library] false).Keys
 
   let optIndex = files |> Seq.tryFind (fun s -> s.EndsWith "index.html")
@@ -425,7 +434,7 @@ let ``MetadataFormat processes C# types and includes xml comments in docs`` () =
 [<Test>]
 let ``MetadataFormat processes C# properties on types and includes xml comments in docs`` () =
     let library = testBin </> "CSharpFormat.dll" |> fullpath
-    
+
     let files = generate [library] false
 
     files.["manoli-utils-csharpformat-clikeformat.html"] |> shouldContainText "CommentRegEx"
@@ -435,7 +444,7 @@ let ``MetadataFormat processes C# properties on types and includes xml comments 
 let ``MetadataFormat generates module link in nested types``() =
 
   let library =  testBin  </> "FsLib2.dll"
-  
+
   let files = generate [library] false
 
   // Check that the modules and type files have namespace information
@@ -468,7 +477,7 @@ let ``MetadataFormat omit works without markdown``() =
   let library = testBin </> "FsLib2.dll" |> fullpath
 
   let files = generate [library] false
-    
+
   files.ContainsKey "fslib-test_omit.html" |> shouldEqual false
 
 [<Test>]
@@ -561,7 +570,7 @@ printfn "MetadataFormat process XML comments in two sample F# assemblies"
 runtest ``MetadataFormat process XML comments in two sample F# assemblies``;;
 
 printfn "MetadataFormat works on sample Deedle assembly"
-runtest ``MetadataFormat works on sample Deedle assembly``;; 
+runtest ``MetadataFormat works on sample Deedle assembly``;;
 
 printfn "MetadataFormat works on two sample F# assemblies"
 runtest ``MetadataFormat works on two sample F# assemblies``;;

--- a/tests/FSharp.MetadataFormat.Tests/files/FsLib/Library2.fs
+++ b/tests/FSharp.MetadataFormat.Tests/files/FsLib/Library2.fs
@@ -5,14 +5,14 @@ namespace FsLib
 type DuplicatedTypeName = int
 
 /// Sample class
-type Class() = 
+type Class() =
   /// Readonly int property
   member x.Member = 0
 
 /// Nested module
-module Nested = 
+module Nested =
   /// Somewhat nested module
-  module Submodule = 
+  module Submodule =
     /// Very nested field
     let supernested = 42
 
@@ -22,7 +22,7 @@ module Nested =
       member x.Member = ""
 
   /// Somewhat nested type
-  type NestedType() = 
+  type NestedType() =
     /// Very nested member
     member x.Member = ""
 
@@ -60,13 +60,38 @@ type Test_Issue229 (name) =
 
     interface ITest_Issue229 with
         /// interface comment
-        member x.Name = name  
+        member x.Name = name
 
 type Test_Issue287 () =
   /// Function Foo!
   abstract member Foo: int-> unit
   /// Empty function for signature
   default x.Foo a = ()
+
+[<RequireQualifiedAccess>]
+module Test_Issue472_R =
+
+  /// test function with tupled arguments
+  let ftupled (x :int, y :int) = x * y
+
+  /// test function with multiple arguments
+  let fmultipleargs (x :int) (y :int) = x * y
+
+module Test_Issue472 =
+
+  /// test function with tupled arguments
+  let ftupled (x :int, y :int) = x * y
+
+  /// test function with multiple arguments
+  let fmultipleargs (x :int) (y :int) = x * y
+
+type Test_Issue472_T () =
+  /// Function MultPartial!
+  member x.MultPartial (arg1:int) (arg2:int) = ()
+  /// Function MultArg!
+  member x.MultArg (arg1:int, arg2:int) = ()
+  /// Function MultArgTupled!
+  member x.MultArgTupled(arg: (int * int)) = ()
 
 type ITestInterface =
   abstract Test : unit -> RazorEngine.Templating.IRazorEngineService
@@ -77,14 +102,14 @@ type ITestInterface =
 module Test_Issue201 =
   /// Extension docs
   [<System.Runtime.CompilerServices.Extension>]
-  let MyExtension (o : ITestInterface) = 
+  let MyExtension (o : ITestInterface) =
     ignore <| o.Test().GetKey(null)
- 
+
 [<AutoOpen>]
 module Test_Issue201Extensions =
   type ITestInterface with
     member x.MyExtension() =
-     Test_Issue201.MyExtension x 
+     Test_Issue201.MyExtension x
 
 /// [omit]
 type Test_Omit() =


### PR DESCRIPTION
fixes #472 

For instance members we now add `x.` in front of the signature and for `RequireQualifiedAccess` and static members we add the type.