### PR TITLE
Fix Literate nuget build

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+## 3.0.0-beta13 
+ - FSharp.Literate for netstandard2.0
+
 ## 3.0.0-beta12 (29, July, 2018)
  - Fix usage formatting - https://github.com/fsprojects/FSharp.Formatting/issues/472
 

--- a/build.fsx
+++ b/build.fsx
@@ -313,7 +313,7 @@ Target.create"NuGet" (fun _ ->
                   "FSharp.Compiler.Service", getPackageVersion "packages" "FSharp.Compiler.Service" |> RequireRange BreakingPoint.SemVer
                   "System.ValueTuple", getPackageVersion "packages" "System.ValueTuple" |> RequireRange BreakingPoint.SemVer
                    ] })
-        "nuget/FSharp.Formatting.nuspec"
+        "nuget/FSharp.Literate.nuspec"
 
     NuGet.NuGet (fun p ->
         { p with

--- a/src/Common/AssemblyInfo.cs
+++ b/src/Common/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Reflection;
 [assembly: AssemblyDescription("A package of libraries for building great F# documentation, samples and blogs")]
 [assembly: AssemblyVersion("3.0.0")]
 [assembly: AssemblyFileVersion("3.0.0")]
-[assembly: AssemblyInformationalVersion("3.0.0-beta12")]
+[assembly: AssemblyInformationalVersion("3.0.0-beta13")]
 [assembly: AssemblyCopyright("Apache 2.0 License")]
 namespace System {
     internal static class AssemblyVersionInformation {
@@ -14,7 +14,7 @@ namespace System {
         internal const System.String AssemblyDescription = "A package of libraries for building great F# documentation, samples and blogs";
         internal const System.String AssemblyVersion = "3.0.0";
         internal const System.String AssemblyFileVersion = "3.0.0";
-        internal const System.String AssemblyInformationalVersion = "3.0.0-beta12";
+        internal const System.String AssemblyInformationalVersion = "3.0.0-beta13";
         internal const System.String AssemblyCopyright = "Apache 2.0 License";
     }
 }

--- a/src/Common/AssemblyInfo.fs
+++ b/src/Common/AssemblyInfo.fs
@@ -6,7 +6,7 @@ open System.Reflection
 [<assembly: AssemblyDescriptionAttribute("A package of libraries for building great F# documentation, samples and blogs")>]
 [<assembly: AssemblyVersionAttribute("3.0.0")>]
 [<assembly: AssemblyFileVersionAttribute("3.0.0")>]
-[<assembly: AssemblyInformationalVersionAttribute("3.0.0-beta12")>]
+[<assembly: AssemblyInformationalVersionAttribute("3.0.0-beta13")>]
 [<assembly: AssemblyCopyrightAttribute("Apache 2.0 License")>]
 do ()
 
@@ -15,5 +15,5 @@ module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyDescription = "A package of libraries for building great F# documentation, samples and blogs"
     let [<Literal>] AssemblyVersion = "3.0.0"
     let [<Literal>] AssemblyFileVersion = "3.0.0"
-    let [<Literal>] AssemblyInformationalVersion = "3.0.0-beta12"
+    let [<Literal>] AssemblyInformationalVersion = "3.0.0-beta13"
     let [<Literal>] AssemblyCopyright = "Apache 2.0 License"


### PR DESCRIPTION
@matthid there was a little mistake in the build of the nuget for FSharp.Literate. It was actually using the nuspec of FSharp.Formatting 😬 

This PR is fixing this hopefully.