### PR TITLE
Fix scaffold link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The library is used by a number of F# projects. Most prominently, the [F# snippe
 uses it to format snippets shared by the F# community. The following sample scripts use the library to generate 
 documentation and might be a useful inspiration:
 
- * [The `generate.fsx` script](https://github.com/fsprojects/FSharp.ProjectScaffold/blob/master/docsrc/tools/generate.template) in `FSharp.ProjectScaffold` shows a recommended way for adding F# Formatting docs to your project.
+ * [The `build.fsx` script](https://github.com/fsprojects/ProjectScaffold/blob/master/build.template) in `FSharp.ProjectScaffold` shows a recommended way for adding F# Formatting docs to your project.
 
 ## Library license
 


### PR DESCRIPTION
this should fix #500 
The code has been moved to build.fsx (actually build.template in scaffold) after the migration to Fake 5 and update to FSharp.Formatting 3.0.0
