### PR TITLE
Add support for customizing assigned CSS class

### DIFF
--- a/src/FSharp.CodeFormat/Main.fs
+++ b/src/FSharp.CodeFormat/Main.fs
@@ -6,25 +6,54 @@
 namespace FSharp.CodeFormat
 
 /// Represents an indivudal formatted snippet with title
-type FormattedSnippet(title:string, content:string) = 
+type FormattedSnippet(title:string, content:string) =
   /// Returns the title of the snippet (or 'Unnamed') if not given
   member x.Title = title
   /// Returns the formatted content code for the snipet
   member x.Content = content
 
 
-/// Represents formatted snippets 
-type FormattedContent(snippets:FormattedSnippet[], tips:string) = 
+/// Represents formatted snippets
+type FormattedContent(snippets:FormattedSnippet[], tips:string) =
   /// Returns the processed snippets as an array
   member x.Snippets = snippets
   /// Returns string with ToolTip elements for all the snippets
   member x.ToolTip = tips
 
+module internal CodeFormatHelper =
+  open Constants
+
+  let defaultTokenMap kind =
+    match kind with
+    | TokenKind.Comment       -> CSS.Comment
+    | TokenKind.Default       -> CSS.Default
+    | TokenKind.Identifier    -> CSS.Identifier
+    | TokenKind.Inactive      -> CSS.Inactive
+    | TokenKind.Keyword       -> CSS.Keyword
+    | TokenKind.Number        -> CSS.Number
+    | TokenKind.Operator      -> CSS.Operator
+    | TokenKind.Preprocessor  -> CSS.Preprocessor
+    | TokenKind.String        -> CSS.String
+    | TokenKind.Module        -> CSS.Module
+    | TokenKind.ReferenceType -> CSS.ReferenceType
+    | TokenKind.ValueType     -> CSS.ValueType
+    | TokenKind.Function      -> CSS.Function
+    | TokenKind.Pattern       -> CSS.Pattern
+    | TokenKind.MutableVar    -> CSS.MutableVar
+    | TokenKind.Printf        -> CSS.Printf
+    | TokenKind.Escaped       -> CSS.Escaped
+    | TokenKind.Disposable    -> CSS.Disposable
+    | TokenKind.TypeArgument  -> CSS.TypeArgument
+    | TokenKind.Punctuation   -> CSS.Punctuation
+    | TokenKind.Enumeration   -> CSS.Enumeration
+    | TokenKind.Interface     -> CSS.Interface
+    | TokenKind.Property      -> CSS.Property
+    | TokenKind.UnionCase     -> CSS.UnionCase
 
 /// Exposes functionality of the F# code formatter with a nice interface
-type CodeFormat = 
+type CodeFormat =
   /// Returns a new instance of the agent that manages code formatting
-  /// using the F# compiler service. The agent requires a reference to 
+  /// using the F# compiler service. The agent requires a reference to
   /// the 'FSharp.Compiler.dll' assembly. At the moment, the assembly
   /// is shared by all the instances of formatting agent!
   static member CreateAgent() = CodeFormatAgent()
@@ -32,31 +61,35 @@ type CodeFormat =
   /// Formats the snippets parsed using the CodeFormatAgent as HTML
   /// The parameters specify prefix for HTML tags, whether lines should
   /// be added to outputs and whether errors should be printed.
-  static member FormatHtml(snippets, prefix, addLines, addErrors) =
+  static member FormatHtml(snippets, prefix, addLines, addErrors, ?tokenKindToCss) =
+    let tokenKindToCss = defaultArg tokenKindToCss CodeFormatHelper.defaultTokenMap
     CodeFormat.FormatHtml
-      ( snippets, prefix, "<pre class=\"fssnip\">", 
-        "</pre>", addLines, addErrors )
+      ( snippets, prefix, "<pre class=\"fssnip\">",
+        "</pre>", addLines, addErrors, tokenKindToCss)
 
   /// Formats the snippets parsed using the CodeFormatAgent as HTML
   /// The parameters specify prefix for HTML tags, whether lines should
   /// be added to outputs and whether errors should be printed.
-  static member FormatHtml(snippets, prefix, openTag, closeTag, addLines, addErrors) =
-    let snip, tip = Html.format addLines addErrors prefix openTag closeTag openTag closeTag snippets 
+  static member FormatHtml(snippets, prefix, openTag, closeTag, addLines, addErrors, ?tokenKindToCss) =
+    let tokenKindToCss = defaultArg tokenKindToCss CodeFormatHelper.defaultTokenMap
+    let snip, tip = Html.format addLines addErrors prefix openTag closeTag openTag closeTag snippets tokenKindToCss
     let snip = [| for t, h in snip -> FormattedSnippet(t, h) |]
     FormattedContent(snip, tip)
 
   /// Formats the snippets parsed using the CodeFormatAgent as HTML
   /// The parameters specify prefix for HTML tags, whether lines should
   /// be added to outputs and whether errors should be printed.
-  static member FormatHtml(snippets, prefix, openTag, closeTag, openLinesTag, closeLinesTag, addLines, addErrors) =
-    let snip, tip = Html.format addLines addErrors prefix openTag closeTag openLinesTag closeLinesTag snippets 
+  static member FormatHtml(snippets, prefix, openTag, closeTag, openLinesTag, closeLinesTag, addLines, addErrors, ?tokenKindToCss) =
+    let tokenKindToCss = defaultArg tokenKindToCss CodeFormatHelper.defaultTokenMap
+    let snip, tip = Html.format addLines addErrors prefix openTag closeTag openLinesTag closeLinesTag snippets tokenKindToCss
     let snip = [| for t, h in snip -> FormattedSnippet(t, h) |]
     FormattedContent(snip, tip)
 
   /// Formats the snippets parsed using the CodeFormatAgent as HTML
   /// using the specified ID prefix and default settings.
-  static member FormatHtml(snippets, prefix) =
-    CodeFormat.FormatHtml(snippets, prefix, true, false)
+  static member FormatHtml(snippets, prefix, ?tokenKindToCss) =
+    let tokenKindToCss = defaultArg tokenKindToCss CodeFormatHelper.defaultTokenMap
+    CodeFormat.FormatHtml(snippets, prefix, true, false, tokenKindToCss)
 
   /// Formats the snippets parsed using the CodeFormatAgent as LaTeX
   /// The parameters specify prefix for LaTeX tags, whether lines should

--- a/src/FSharp.Literate/Contexts.fs
+++ b/src/FSharp.Literate/Contexts.fs
@@ -5,13 +5,13 @@ open FSharp.CodeFormat
 /// Specifies a context that is passed to functions
 /// that need to use the F# compiler
 type CompilerContext =
-  { // An instance of the F# code formatting agent
+  { /// An instance of the F# code formatting agent
     FormatAgent : CodeFormatAgent
-    // F# interactive evaluator
+    /// F# interactive evaluator
     Evaluator : IFsiEvaluator option
-    // Command line options for the F# compiler
+    /// Command line options for the F# compiler
     CompilerOptions : string option
-    // Defined symbols for the F# compiler
+    /// Defined symbols for the F# compiler
     DefinedSymbols : string option }
 
 /// Defines the two possible output types from literate script: HTML and LaTeX.
@@ -29,15 +29,17 @@ type GeneratorOutput =
 
 /// Specifies a context that is passed to functions that generate the output
 type ProcessingContext =
-  { // Short prefix code added to all HTML 'id' elements
+  { /// Short prefix code added to all HTML 'id' elements
     Prefix : string
-    // Additional replacements to be made in the template file
+    /// Additional replacements to be made in the template file
     Replacements : list<string * string>
-    // Generate line numbers for F# snippets?
+    /// Generate line numbers for F# snippets?
     GenerateLineNumbers : bool
-    // Include the source file in the generated output as '{source}'
+    /// Include the source file in the generated output as '{source}'
     IncludeSource : bool
-    // Auto-generate anchors for headers
+    /// Auto-generate anchors for headers
     GenerateHeaderAnchors : bool
-    // The output format
-    OutputKind : OutputKind }
+    /// The output format
+    OutputKind : OutputKind
+    /// Function assigning CSS class to given token kind. If not specified, default mapping will be used
+    TokenKindToCss : (TokenKind -> string) option }

--- a/src/FSharp.Literate/Transformations.fs
+++ b/src/FSharp.Literate/Transformations.fs
@@ -12,7 +12,7 @@ open FSharp.CodeFormat
 open FSharp.Markdown
 
 /// [omit]
-module Transformations = 
+module Transformations =
   // ----------------------------------------------------------------------------------------------
   // Replace all code snippets (assume F#) with their nicely formatted versions
   // ----------------------------------------------------------------------------------------------
@@ -25,14 +25,14 @@ module Transformations =
         when (not (String.IsNullOrWhiteSpace(language)) && language <> "fsharp") || (cmds.ContainsKey("lang") && cmds.["lang"] <> "fsharp") -> ()
     | CodeBlock((String.StartsWithWrapped ("[", "]") (ParseCommands cmds, String.SkipSingleLine code)), _, _, _)
     | CodeBlock(Let (dict []) (cmds, code), _, _, _) ->
-        let modul = 
+        let modul =
           match cmds.TryGetValue("module") with
           | true, v -> Some v | _ -> None
         yield modul, code
     | Matching.ParagraphLeaf _ -> ()
-    | Matching.ParagraphNested(_, pars) -> 
-        for ps in pars do 
-          for p in ps do yield! collectCodeSnippets p 
+    | Matching.ParagraphNested(_, pars) ->
+        for ps in pars do
+          for p in ps do yield! collectCodeSnippets p
     | Matching.ParagraphSpans(_, spans) -> () }
 
 
@@ -42,23 +42,23 @@ module Transformations =
     | CodeBlock ((String.StartsWithWrapped ("[", "]") (ParseCommands cmds, String.SkipSingleLine code)), language, _, r)
     | CodeBlock(Let (dict []) (cmds, code), language, _, r) ->
         if cmds.ContainsKey("hide") then None else
-        let code = 
-          if cmds.ContainsKey("file") && cmds.ContainsKey("key") then 
+        let code =
+          if cmds.ContainsKey("file") && cmds.ContainsKey("key") then
             // Get snippet from an external file
             let file = Path.Combine(Path.GetDirectoryName(path), cmds.["file"])
             let startTag, endTag = "[" + cmds.["key"] + "]", "[/" + cmds.["key"] + "]"
             let lines = File.ReadAllLines(file)
             let startIdx = lines |> Seq.findIndex (fun l -> l.Contains startTag)
             let endIdx = lines |> Seq.findIndex (fun l -> l.Contains endTag)
-            lines.[startIdx + 1 .. endIdx - 1] 
+            lines.[startIdx + 1 .. endIdx - 1]
             |> String.removeSpaces
             |> String.concat "\n"
           else code
-        let lang = 
+        let lang =
           match language with
           | String.WhiteSpace when cmds.ContainsKey("lang") -> cmds.["lang"]
           | language -> language
-        if not (String.IsNullOrWhiteSpace(lang)) && lang <> "fsharp" then 
+        if not (String.IsNullOrWhiteSpace(lang)) && lang <> "fsharp" then
           Some (EmbedParagraphs(LanguageTaggedCode(lang, code), r))
         else
           Some (EmbedParagraphs(FormattedCode(codeLookup.[code]), r))
@@ -70,14 +70,14 @@ module Transformations =
     | other -> Some other
 
 
-  /// Walk over literate document and replace F# code snippets with 
+  /// Walk over literate document and replace F# code snippets with
   /// their formatted representation (of `LiterateParagraph` type)
   let formatCodeSnippets path ctx (doc:LiterateDocument) =
     let name = Path.GetFileNameWithoutExtension(path)
 
     // Extract all CodeBlocks and pass them to F# snippets
     let codes = doc.Paragraphs |> Seq.collect collectCodeSnippets |> Array.ofSeq
-    let snippetLookup, errors = 
+    let snippetLookup, errors =
       if codes.Length = 0 then dict [], [||] else
         // If there are some F# snippets, we build an F# source file
         let blocks = codes |> Seq.mapi (fun index -> function
@@ -90,18 +90,18 @@ module Transformations =
           | None, code ->
               "// [snippet:" + (string index) + "]\n" +
               code + "\n" +
-              "// [/snippet]" ) 
+              "// [/snippet]" )
         let modul = "module " + (new String(name |> Seq.filter Char.IsLetter |> Seq.toArray))
         let source = modul + "\r\n" + (String.concat "\n\n" blocks)
 
         // Process F# script file & build lookup table for replacement
-        let snippets, errors = 
+        let snippets, errors =
           ctx.FormatAgent.ParseSource
-            ( Path.ChangeExtension(path, ".fsx"), source, 
+            ( Path.ChangeExtension(path, ".fsx"), source,
               ?options = ctx.CompilerOptions, ?defines = ctx.DefinedSymbols )
-        [ for (_, code), (Snippet(_, fs)) in Array.zip codes snippets -> 
+        [ for (_, code), (Snippet(_, fs)) in Array.zip codes snippets ->
             code, fs ] |> dict, errors
-    
+
     // Replace code blocks with formatted snippets in the document
     let newPars = doc.Paragraphs |> List.choose (replaceCodeSnippets path snippetLookup)
     doc.With(paragraphs = newPars, errors = Seq.append doc.Errors errors)
@@ -110,11 +110,11 @@ module Transformations =
   // Generate references from indirect links
   // ----------------------------------------------------------------------------------------------
 
-  /// Given Markdown document, get the keys of all IndirectLinks 
+  /// Given Markdown document, get the keys of all IndirectLinks
   /// (to be used when generating paragraph with all references)
-  let rec collectReferences = 
+  let rec collectReferences =
     // Collect IndirectLinks in a span
-    let rec collectSpanReferences span = seq { 
+    let rec collectSpanReferences span = seq {
       match span with
       | IndirectLink(_, _, key, _) -> yield key
       | Matching.SpanLeaf _ -> ()
@@ -124,15 +124,15 @@ module Transformations =
     let rec loop par = seq {
       match par with
       | Matching.ParagraphLeaf _ -> ()
-      | Matching.ParagraphNested(_, pars) -> 
-          for ps in pars do 
-            for p in ps do yield! loop p 
+      | Matching.ParagraphNested(_, pars) ->
+          for ps in pars do
+            for p in ps do yield! loop p
       | Matching.ParagraphSpans(_, spans) ->
           for s in spans do yield! collectSpanReferences s }
-    loop 
+    loop
 
 
-  /// Given Markdown document, add a number using the given index to all indirect 
+  /// Given Markdown document, add a number using the given index to all indirect
   /// references. For example, [article][ref] becomes [article][ref] [1](#rfxyz)
   let replaceReferences (refIndex:IDictionary<string, int>) =
     // Replace IndirectLinks with a nice link given a single span element
@@ -140,30 +140,30 @@ module Transformations =
       | IndirectLink(body, original, key, r) ->
           [ yield IndirectLink(body, original, key, r)
             match refIndex.TryGetValue(key) with
-            | true, i -> 
+            | true, i ->
                 yield Literal("&#160;[", r)
                 yield DirectLink([Literal (string i, r)], "#rf" + DateTime.Now.ToString("yyMMddhh"), None, r)
                 yield Literal("]", r)
             | _ -> () ]
       | Matching.SpanLeaf(sl) -> [Matching.SpanLeaf(sl)]
-      | Matching.SpanNode(nd, spans) -> 
+      | Matching.SpanNode(nd, spans) ->
           [ Matching.SpanNode(nd, List.collect replaceSpans spans) ]
     // Given a paragraph, process it recursively and transform all spans
     let rec loop = function
       | Matching.ParagraphNested(pn, nested) ->
           Matching.ParagraphNested(pn, List.map (List.choose loop) nested) |> Some
-      | Matching.ParagraphSpans(ps, spans) -> 
+      | Matching.ParagraphSpans(ps, spans) ->
           Matching.ParagraphSpans(ps, List.collect replaceSpans spans) |> Some
-      | Matching.ParagraphLeaf(pl) -> Matching.ParagraphLeaf(pl) |> Some   
+      | Matching.ParagraphLeaf(pl) -> Matching.ParagraphLeaf(pl) |> Some
     loop
 
 
   /// Given all links defined in the Markdown document and a list of all links
   /// that are accessed somewhere from the document, generate References paragraph
-  let generateRefParagraphs (definedLinks:IDictionary<_, string * string option>) refs =     
-    // For all unique references in the document, 
+  let generateRefParagraphs (definedLinks:IDictionary<_, string * string option>) refs =
+    // For all unique references in the document,
     // get the link & title from definitions
-    let refs = 
+    let refs =
       refs |> set |> Seq.choose (fun ref ->
         match definedLinks.TryGetValue(ref) with
         | true, (link, Some title) -> Some (ref, link, title)
@@ -173,15 +173,15 @@ module Transformations =
     let refLookup = dict [ for (i, (r, _, _)) in refs -> r, i ]
 
     // Generate Markdown blocks paragraphs representing Reference <li> items
-    let refList = 
-      [ for i, (ref, link, title) in refs do 
+    let refList =
+      [ for i, (ref, link, title) in refs do
           let colon = title.IndexOf(":")
           if colon > 0 then
             let auth = title.Substring(0, colon)
             let name = title.Substring(colon + 1, title.Length - 1 - colon)
             yield [Span([ Literal (sprintf "[%d] " i, None)
                           DirectLink([Literal (name.Trim(), None)], link, Some title, None)
-                          Literal (" - " + auth, None)], None) ] 
+                          Literal (" - " + auth, None)], None) ]
           else
             yield [Span([ Literal (sprintf "[%d] " i, None)
                           DirectLink([Literal(title, None)], link, Some title, None)], None)]  ]
@@ -192,11 +192,11 @@ module Transformations =
       Heading(3, [Literal("References", None)], None)
       ListBlock(MarkdownListKind.Unordered, refList, None) ], refLookup
 
-  /// Turn all indirect links into a references 
+  /// Turn all indirect links into a references
   /// and add paragraph to the document
   let generateReferences (doc:LiterateDocument) =
     let refs = doc.Paragraphs |> Seq.collect collectReferences
-    let refPars, refLookup = generateRefParagraphs doc.DefinedLinks refs 
+    let refPars, refLookup = generateRefParagraphs doc.DefinedLinks refs
     let newDoc = doc.Paragraphs |> List.choose (replaceReferences refLookup)
     doc.With(paragraphs = newDoc @ refPars)
 
@@ -206,7 +206,7 @@ module Transformations =
 
   /// Represents key in a dictionary with evaluation results
   type EvalKey = OutputRef of string | ValueRef of string
-   
+
   /// Unparse a Line list to a string - for evaluation by fsi.
   let unparse (lines: Line list) =
     let joinLine (Line spans) =
@@ -219,10 +219,10 @@ module Transformations =
 
   /// Evaluate all the snippets in a literate document, returning the results.
   /// The result is a map of string * bool to FsiEvaluationResult. The bool indicates
-  /// whether the result is a top level variable (i.e. include-value) or a reference to 
+  /// whether the result is a top level variable (i.e. include-value) or a reference to
   /// some output (i.e. define-output and include-output). This just to put each of those
   /// names in a separate scope.
-  let rec evalBlocks (fsi:IFsiEvaluator) file acc (paras:MarkdownParagraphs) = 
+  let rec evalBlocks (fsi:IFsiEvaluator) file acc (paras:MarkdownParagraphs) =
     match paras with
     | Matching.LiterateParagraph(para)::paras ->
       match para with
@@ -241,9 +241,9 @@ module Transformations =
           // Need to eval because subsequent code might refer it, but we don't need result
           let text = unparse snip
           let result = fsi.Evaluate(text, false, Some file)
-          evalBlocks fsi file acc paras 
+          evalBlocks fsi file acc paras
 
-      | ValueReference(ref) -> 
+      | ValueReference(ref) ->
           let result = fsi.Evaluate(ref, true, Some file)
           evalBlocks fsi file ((ValueRef ref,result)::acc) paras
       | _ -> evalBlocks fsi file acc paras
@@ -251,24 +251,24 @@ module Transformations =
     | [] -> acc
 
   /// Given an evaluator and document, evaluate all code snippets and return a map with
-  /// their results - the key is `ValueRef(name)` for all value references and 
+  /// their results - the key is `ValueRef(name)` for all value references and
   /// `OutputRef(name)` for all references to the snippet console output
-  let evalAllSnippets fsi (doc:LiterateDocument) = 
+  let evalAllSnippets fsi (doc:LiterateDocument) =
     evalBlocks fsi doc.SourceFile [] doc.Paragraphs |> Map.ofList
-    
+
 
   // ---------------------------------------------------------------------------------------------
   // Evaluate all snippets and replace evaluation references with the results
   // ---------------------------------------------------------------------------------------------
 
   let rec replaceEvaluations ctx (evaluationResults:Map<_, IFsiEvaluationResult>) = function
-    | Matching.LiterateParagraph(special) -> 
+    | Matching.LiterateParagraph(special) ->
         let (|EvalFormat|_|) = function
           | OutputReference(ref) -> Some(evaluationResults.TryFind(OutputRef ref), ref, FsiEmbedKind.Output)
           | ItValueReference(ref) -> Some(evaluationResults.TryFind(OutputRef ref), ref, FsiEmbedKind.ItValue)
           | ValueReference(ref) -> Some(evaluationResults.TryFind(ValueRef ref), ref, FsiEmbedKind.Value)
           | _ -> None
-        match special with 
+        match special with
         | EvalFormat(Some result, _, kind) -> ctx.Evaluator.Value.Format(result, kind)
         | EvalFormat(None, ref, _) -> [ CodeBlock("Could not find reference '" + ref + "'", "", "", None) ]
         | other -> [ EmbedParagraphs(other, None) ]
@@ -293,14 +293,14 @@ module Transformations =
   // ----------------------------------------------------------------------------------------------
 
   /// Collect all code snippets in the document (so that we can format all of them)
-  /// The resulting dictionary has Choice as the key, so that we can distinguish 
+  /// The resulting dictionary has Choice as the key, so that we can distinguish
   /// between moved snippets and ordinary snippets
   let rec collectCodes par = seq {
-    match par with 
-    | Matching.LiterateParagraph(LiterateCode(lines, { Visibility = NamedCode id })) -> 
+    match par with
+    | Matching.LiterateParagraph(LiterateCode(lines, { Visibility = NamedCode id })) ->
         yield Choice2Of2(id), lines
-    | Matching.LiterateParagraph(LiterateCode(lines, _)) 
-    | Matching.LiterateParagraph(FormattedCode(lines)) -> 
+    | Matching.LiterateParagraph(LiterateCode(lines, _))
+    | Matching.LiterateParagraph(FormattedCode(lines)) ->
         yield Choice1Of2(lines), lines
     | Matching.ParagraphNested(pn, nested) ->
         yield! Seq.collect (Seq.collect collectCodes) nested
@@ -309,26 +309,26 @@ module Transformations =
 
   /// Replace all special 'LiterateParagraph' elements recursively using the given lookup dictionary
   let rec replaceSpecialCodes ctx (formatted:IDictionary<_, _>) = function
-    | Matching.LiterateParagraph(special) -> 
+    | Matching.LiterateParagraph(special) ->
         match special with
         | RawBlock lines -> Some (InlineBlock(unparse lines, None))
         | LiterateCode(_, { Visibility = (HiddenCode | NamedCode _) }) -> None
-        | FormattedCode lines 
+        | FormattedCode lines
         | LiterateCode(lines, _) -> Some (formatted.[Choice1Of2 lines])
         | CodeReference ref -> Some (formatted.[Choice2Of2 ref])
-        | OutputReference _  
-        | ItValueReference _  
-        | ValueReference _ -> 
+        | OutputReference _
+        | ItValueReference _
+        | ValueReference _ ->
             failwith "Output, it-value and value references should be replaced by FSI evaluator"
-        | LanguageTaggedCode(lang, code) -> 
-            let inlined = 
+        | LanguageTaggedCode(lang, code) ->
+            let inlined =
               match ctx.OutputKind with
               | OutputKind.Html ->
                   let sb = new System.Text.StringBuilder()
                   let writer = new System.IO.StringWriter(sb)
                   writer.Write("<table class=\"pre\">")
                   writer.Write("<tr>")
-                  if ctx.GenerateLineNumbers then 
+                  if ctx.GenerateLineNumbers then
                     // Split the formatted code into lines & emit line numbers in <td>
                     // (Similar to formatSnippets in FSharp.CodeFormat\HtmlFormatting.fs)
                     let lines = code.Trim('\r', '\n').Replace("\r\n", "\n").Replace("\n\r", "\n").Replace("\r", "\n").Split('\n')
@@ -342,7 +342,7 @@ module Transformations =
                     writer.WriteLine("</td>")
 
                   writer.Write("<td class=\"snippet\">")
-                  
+
                   match SyntaxHighlighter.FormatCode(lang, code) with
                   | true, code -> Printf.fprintf writer "<pre class=\"fssnip highlighted\"><code lang=\"%s\">%s</code></pre>" lang code
                   | false, code -> Printf.fprintf writer "<pre class=\"fssnip\"><code lang=\"%s\">%s</code></pre>" lang code
@@ -361,26 +361,26 @@ module Transformations =
 
 
   /// Replace all special 'LiterateParagraph' elements with ordinary HTML/Latex
-  let replaceLiterateParagraphs ctx (doc:LiterateDocument) = 
+  let replaceLiterateParagraphs ctx (doc:LiterateDocument) =
     let replacements = Seq.collect collectCodes doc.Paragraphs
     let snippets = [| for _, r in replacements -> Snippet("", r) |]
-    
+
     // Format all snippets and build lookup dictionary for replacements
     let formatted =
       match ctx.OutputKind with
-      | OutputKind.Html -> 
+      | OutputKind.Html ->
           let openTag = "<pre class=\"fssnip highlighted\"><code lang=\"fsharp\">"
           let closeTag = "</code></pre>"
           let openLinesTag = "<pre class=\"fssnip\">"
           let closeLinesTag = "</pre>"
           CodeFormat.FormatHtml
-            ( snippets, ctx.Prefix, openTag, closeTag, 
-              openLinesTag, closeLinesTag, ctx.GenerateLineNumbers, false)
+            ( snippets, ctx.Prefix, openTag, closeTag,
+              openLinesTag, closeLinesTag, ctx.GenerateLineNumbers, false, ?tokenKindToCss = ctx.TokenKindToCss)
       | OutputKind.Latex -> CodeFormat.FormatLatex(snippets, ctx.GenerateLineNumbers)
-    let lookup = 
-      [ for (key, _), fmtd in Seq.zip replacements formatted.Snippets -> 
-          key, InlineBlock(fmtd.Content, None) ] |> dict 
-    
+    let lookup =
+      [ for (key, _), fmtd in Seq.zip replacements formatted.Snippets ->
+          key, InlineBlock(fmtd.Content, None) ] |> dict
+
     // Replace original snippets with formatted HTML/Latex and return document
     let newParagraphs = List.choose (replaceSpecialCodes ctx lookup) doc.Paragraphs
     doc.With(paragraphs = newParagraphs, formattedTips = formatted.ToolTip)

--- a/tests/FSharp.CodeFormat.Tests/Tests.fs
+++ b/tests/FSharp.CodeFormat.Tests/Tests.fs
@@ -20,24 +20,24 @@ open FsUnitTyped
 let agent = CodeFormat.CreateAgent()
 
 // Check that snippet constains a specific span
-let containsSpan f snips = 
+let containsSpan f snips =
   snips |> Seq.exists (fun (Snippet(_, lines)) ->
     lines |> Seq.exists (fun (Line spans) -> spans |> Seq.exists f))
 
 // Check that tool tips contains a specified token
-let (|ToolTipWithLiteral|_|) text tips = 
+let (|ToolTipWithLiteral|_|) text tips =
   if Seq.exists (function Literal(tip) -> tip.Contains(text: string) | _ -> false) tips
   then Some () else None
-  
+
 // --------------------------------------------------------------------------------------
 // Test that some basic things work
 // --------------------------------------------------------------------------------------
 
 [<Test>]
-let ``Simple code snippet is formatted with tool tips``() = 
+let ``Simple code snippet is formatted with tool tips``() =
   let source = """let hello = 10"""
   let snips, errors = agent.ParseSource("/somewhere/test.fsx", source.Trim())
-  
+
   errors |> shouldEqual [| |]
   snips |> containsSpan (function
     | Token(_, "hello", Some (ToolTipWithLiteral "val hello : int")) -> true
@@ -52,12 +52,12 @@ let getContentAndToolTip (source: string) =
 let getContent = getContentAndToolTip >> fst
 
 [<Test>]
-let ``Simple code snippet is formatted as HTML``() = 
+let ``Simple code snippet is formatted as HTML``() =
     let content, tooltip = getContentAndToolTip """let hello = 10"""
     content |> shouldContainText (sprintf "<span class=\"%s\">let</span>" CSS.Keyword)
     content |> shouldContainText ">hello<"
     content |> shouldContainText (sprintf "<span class=\"%s\">10</span>" CSS.Number)
-    tooltip |> shouldContainText "val hello : int" 
+    tooltip |> shouldContainText "val hello : int"
 
 [<Test>]
 let ``Non-unicode characters do not cause exception`` () =
@@ -70,29 +70,29 @@ let ``Non-unicode characters do not cause exception`` () =
 // [/snippet]"""
   let snips, errors = agent.ParseSource("/somewhere/test.fsx", source.Trim())
   errors.Length |> shouldBeGreaterThan 0
-  let (SourceError(_, _, _, msg)) = errors.[0] 
+  let (SourceError(_, _, _, msg)) = errors.[0]
   msg |> shouldContainText "✘"
 
 [<Test>]
-let ``Plain string is in span of 's' class when it's the last token in the line``() = 
+let ``Plain string is in span of 's' class when it's the last token in the line``() =
   getContent """let _ = "str" """ |> shouldContainText (sprintf "<span class=\"%s\">&quot;str&quot;</span>" CSS.String)
 
 [<Test>]
-let ``Plain string is in span of 's' class, there are several other tokens next to it``() = 
+let ``Plain string is in span of 's' class, there are several other tokens next to it``() =
   let content = getContent """let _ = "str", 1 """
   content |> shouldContainText (sprintf "<span class=\"%s\">&quot;str&quot;</span>" CSS.String)
   content |> shouldNotContainText (sprintf  "<span class=\"%s\">,</span>" CSS.String)
   content |> shouldContainText ","
 
 [<Test>]
-let ``Plain string is in span of 's' class, there is punctuation next to it``() = 
+let ``Plain string is in span of 's' class, there is punctuation next to it``() =
   let content = getContent """let _ = ("str")"""
   content |> shouldContainText (sprintf "<span class=\"%s\">(</span>" CSS.Punctuation)
   content |> shouldContainText (sprintf  "<span class=\"%s\">&quot;str&quot;</span>" CSS.String)
   content |> shouldContainText (sprintf "<span class=\"%s\">)</span>" CSS.Punctuation)
 
 [<Test>]
-let ``Modules and types are in spans of 't' class``() = 
+let ``Modules and types are in spans of 't' class``() =
   let content = getContent """
 module Module =
   type Type() = class end
@@ -101,7 +101,7 @@ module Module =
   content |> shouldContainText (sprintf "class=\"%s\">Type</span>" CSS.ReferenceType)
 
 [<Test>]
-let ``Functions and methods are in spans of 'f' class``() = 
+let ``Functions and methods are in spans of 'f' class``() =
   let content = getContent """
 module M =
     type T() =
@@ -114,7 +114,7 @@ module M =
   content |> shouldContainText (sprintf "class=\"%s\">func2</span>" CSS.Function )
 
 [<Test>]
-let ``Printf formatters are in spans of 'pf' class``() = 
+let ``Printf formatters are in spans of 'pf' class``() =
   let content = getContent """let _ = sprintf "a %A b %0.3fD" """
   content |> shouldContainText (sprintf "class=\"%s\">&quot;a </span>" CSS.String)
   content |> shouldContainText (sprintf "class=\"%s\">%%A</span>" CSS.Printf     )
@@ -123,7 +123,7 @@ let ``Printf formatters are in spans of 'pf' class``() =
   content |> shouldContainText (sprintf "class=\"%s\">D&quot;</span>" CSS.String )
 
 [<Test>][<Ignore "FCS doesn't currently have semantic highlighting for escaped chars in a string">]
-let ``Escaped characters are in spans of 'esc' class``() = 
+let ``Escaped characters are in spans of 'esc' class``() =
   let content = getContent """let _ = sprintf "a \n\tD\uA0A0 \t" """
   content |> shouldContainText (sprintf "class=\"%s\">&quot;a </span>" CSS.String)
   content |> shouldContainText (sprintf "class=\"%s\">\\n</span>" CSS.Escaped)
@@ -132,3 +132,112 @@ let ``Escaped characters are in spans of 'esc' class``() =
   content |> shouldContainText (sprintf "class=\"%s\">\\uA0A0</span>" CSS.Escaped)
   content |> shouldContainText (sprintf "class=\"%s\"> </span>" CSS.String)
   content |> shouldContainText (sprintf "class=\"%s\">\\t</span>" CSS.Escaped)
+
+// --------------------------------------------------------------------------------------
+// Test with custom css
+// --------------------------------------------------------------------------------------
+
+let customCss kind =
+    match kind with
+    | TokenKind.Comment       -> "Comment"
+    | TokenKind.Default       -> "Default"
+    | TokenKind.Identifier    -> "Identifier"
+    | TokenKind.Inactive      -> "Inactive"
+    | TokenKind.Keyword       -> "Keyword"
+    | TokenKind.Number        -> "Number"
+    | TokenKind.Operator      -> "Operator"
+    | TokenKind.Preprocessor  -> "Preprocessor"
+    | TokenKind.String        -> "String"
+    | TokenKind.Module        -> "Module"
+    | TokenKind.ReferenceType -> "ReferenceType"
+    | TokenKind.ValueType     -> "ValueType"
+    | TokenKind.Function      -> "Function"
+    | TokenKind.Pattern       -> "Pattern"
+    | TokenKind.MutableVar    -> "MutableVar"
+    | TokenKind.Printf        -> "Printf"
+    | TokenKind.Escaped       -> "Escaped"
+    | TokenKind.Disposable    -> "Disposable"
+    | TokenKind.TypeArgument  -> "TypeArgument"
+    | TokenKind.Punctuation   -> "Punctuation"
+    | TokenKind.Enumeration   -> "Enumeration"
+    | TokenKind.Interface     -> "Interface"
+    | TokenKind.Property      -> "Property"
+    | TokenKind.UnionCase     -> "UnionCase"
+
+
+
+let getContentAndToolTip' (source: string) =
+  let snips, _errors = agent.ParseSource("/somewhere/test.fsx", source.Trim())
+  let res = CodeFormat.FormatHtml(snips, "fstips", tokenKindToCss = customCss)
+  (Seq.head res.Snippets).Content, res.ToolTip
+
+let getContent' = getContentAndToolTip' >> fst
+
+[<Test>]
+let ``Simple code snippet is formatted as HTML - custom CSS``() =
+    let content, tooltip = getContentAndToolTip' """let hello = 10"""
+    content |> shouldContainText (sprintf "<span class=\"%s\">let</span>" "Keyword")
+    content |> shouldContainText ">hello<"
+    content |> shouldContainText (sprintf "<span class=\"%s\">10</span>" "Number")
+    tooltip |> shouldContainText "val hello : int"
+
+
+[<Test>]
+let ``Plain string is in span of 's' class when it's the last token in the line - custom CSS``() =
+  getContent' """let _ = "str" """ |> shouldContainText (sprintf "<span class=\"%s\">&quot;str&quot;</span>" "String")
+
+[<Test>]
+let ``Plain string is in span of 's' class, there are several other tokens next to it - custom CSS``() =
+  let content = getContent' """let _ = "str", 1 """
+  content |> shouldContainText (sprintf "<span class=\"%s\">&quot;str&quot;</span>" "String")
+  content |> shouldNotContainText (sprintf  "<span class=\"%s\">,</span>" "String")
+  content |> shouldContainText ","
+
+[<Test>]
+let ``Plain string is in span of 's' class, there is punctuation next to it - custom CSS``() =
+  let content = getContent' """let _ = ("str")"""
+  content |> shouldContainText (sprintf "<span class=\"%s\">(</span>" "Punctuation")
+  content |> shouldContainText (sprintf  "<span class=\"%s\">&quot;str&quot;</span>" "String")
+  content |> shouldContainText (sprintf "<span class=\"%s\">)</span>" "Punctuation")
+
+[<Test>]
+let ``Modules and types are in spans of 't' class - custom CSS``() =
+  let content = getContent' """
+module Module =
+  type Type() = class end
+"""
+  content |> shouldContainText (sprintf "class=\"%s\">Module</span>" "Module")
+  content |> shouldContainText (sprintf "class=\"%s\">Type</span>" "ReferenceType")
+
+[<Test>]
+let ``Functions and methods are in spans of 'f' class - custom CSS``() =
+  let content = getContent' """
+module M =
+    type T() =
+        let func1 x = ()
+        member __.Method x = ()
+    let func2 x y = x + y
+"""
+  content |> shouldContainText (sprintf "class=\"%s\">func1</span>" "Function" )
+  content |> shouldContainText (sprintf "class=\"%s\">Method</span>" "Function")
+  content |> shouldContainText (sprintf "class=\"%s\">func2</span>" "Function" )
+
+[<Test>]
+let ``Printf formatters are in spans of 'pf' class - custom CSS``() =
+  let content = getContent' """let _ = sprintf "a %A b %0.3fD" """
+  content |> shouldContainText (sprintf "class=\"%s\">&quot;a </span>" "String")
+  content |> shouldContainText (sprintf "class=\"%s\">%%A</span>" "Printf"     )
+  content |> shouldContainText (sprintf "class=\"%s\"> b </span>" "String"     )
+  content |> shouldContainText (sprintf "class=\"%s\">%%0.3f</span>" "Printf"  )
+  content |> shouldContainText (sprintf "class=\"%s\">D&quot;</span>" "String" )
+
+[<Test>][<Ignore "FCS doesn't currently have semantic highlighting for escaped chars in a string">]
+let ``Escaped characters are in spans of 'esc' class - custom CSS``() =
+  let content = getContent' """let _ = sprintf "a \n\tD\uA0A0 \t" """
+  content |> shouldContainText (sprintf "class=\"%s\">&quot;a </span>" "String")
+  content |> shouldContainText (sprintf "class=\"%s\">\\n</span>" "Escaped")
+  content |> shouldContainText (sprintf "class=\"%s\">\\t</span>" "Escaped")
+  content |> shouldContainText (sprintf "class=\"%s\">D</span>" "String")
+  content |> shouldContainText (sprintf "class=\"%s\">\\uA0A0</span>" "Escaped")
+  content |> shouldContainText (sprintf "class=\"%s\"> </span>" "String")
+  content |> shouldContainText (sprintf "class=\"%s\">\\t</span>" "Escaped")


### PR DESCRIPTION
In my case I'd want to use standard hihglighting.js CSS classes rather than built-in ones - I'm using highlighting.JS for syntax highlighting of non-F# code snippets so I'd like to be consistent. 