### PR TITLE
Fix exception tag support

### DIFF
--- a/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
+++ b/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
@@ -908,7 +908,7 @@ module internal Reader =
      full.Append("</p>") |> ignore
    )
 
-   let exceptions = doc.Descendants(XName.Get "exceptions")
+   let exceptions = doc.Descendants(XName.Get "exception")
    if Seq.length exceptions > 0 then
      full.Append("<h4>Exceptions</h4>") |> ignore
      full.Append("<table>") |> ignore


### PR DESCRIPTION
According to docs its `exception` not `exceptions` - https://docs.microsoft.com/en-us/dotnet/csharp/codedoc#exception