### PR TITLE
Add support for <c> tag in XML Docs 

### DIFF
--- a/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
+++ b/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
@@ -871,6 +871,10 @@ module internal Reader =
               full.AppendFormat("<a href=\"{0}\">{1}</a>", reference.ReferenceLink, reference.NiceName) |> ignore
             | _ ->
               full.AppendFormat("UNRESOLVED({0})", cref.Value) |> ignore
+        | "c" ->
+           full.Append("<code>") |> ignore
+           full.Append(elem.Value) |> ignore
+           full.Append("</code>") |> ignore
         | _ ->
           ()
        ) (e.Nodes())


### PR DESCRIPTION
`<c>...</c>` [marks inline code](https://docs.microsoft.com/en-us/dotnet/csharp/codedoc#c) - in HTML we have `<code>... </code>` [for this](https://www.w3schools.com/tags/tag_code.asp)