### PR TITLE
fix formatting of generic parameters

### DIFF
--- a/FSharp.Formatting.sln
+++ b/FSharp.Formatting.sln
@@ -37,7 +37,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{312E452A-1
 		docs\codeformat.fsx = docs\codeformat.fsx
 		docs\commandline.md = docs\commandline.md
 		docs\content.fsx = docs\content.fsx
-		docs\development.md = docs\development.md
 		docs\diagnostics.md = docs\diagnostics.md
 		docs\evaluation.fsx = docs\evaluation.fsx
 		docs\index.md = docs\index.md

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+## 6.0.7
+  - fix formatting of generic parameters so they don't show inference variables for members
+
 ## 6.0.6
   - fix default styling
 

--- a/src/Common/AssemblyInfo.cs
+++ b/src/Common/AssemblyInfo.cs
@@ -4,17 +4,17 @@ using System.Reflection;
 
 [assembly: AssemblyProduct("FSharp.Formatting")]
 [assembly: AssemblyDescription("A package of libraries for building great F# documentation, samples and blogs")]
-[assembly: AssemblyVersion("6.0.6")]
-[assembly: AssemblyFileVersion("6.0.6")]
-[assembly: AssemblyInformationalVersion("6.0.6")]
+[assembly: AssemblyVersion("6.0.7")]
+[assembly: AssemblyFileVersion("6.0.7")]
+[assembly: AssemblyInformationalVersion("6.0.7")]
 [assembly: AssemblyCopyright("Apache 2.0 License")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyProduct = "FSharp.Formatting";
         internal const System.String AssemblyDescription = "A package of libraries for building great F# documentation, samples and blogs";
-        internal const System.String AssemblyVersion = "6.0.6";
-        internal const System.String AssemblyFileVersion = "6.0.6";
-        internal const System.String AssemblyInformationalVersion = "6.0.6";
+        internal const System.String AssemblyVersion = "6.0.7";
+        internal const System.String AssemblyFileVersion = "6.0.7";
+        internal const System.String AssemblyInformationalVersion = "6.0.7";
         internal const System.String AssemblyCopyright = "Apache 2.0 License";
     }
 }

--- a/src/Common/AssemblyInfo.cs
+++ b/src/Common/AssemblyInfo.cs
@@ -4,17 +4,17 @@ using System.Reflection;
 
 [assembly: AssemblyProduct("FSharp.Formatting")]
 [assembly: AssemblyDescription("A package of libraries for building great F# documentation, samples and blogs")]
-[assembly: AssemblyVersion("6.0.5")]
-[assembly: AssemblyFileVersion("6.0.5")]
-[assembly: AssemblyInformationalVersion("6.0.5")]
+[assembly: AssemblyVersion("6.0.6")]
+[assembly: AssemblyFileVersion("6.0.6")]
+[assembly: AssemblyInformationalVersion("6.0.6")]
 [assembly: AssemblyCopyright("Apache 2.0 License")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyProduct = "FSharp.Formatting";
         internal const System.String AssemblyDescription = "A package of libraries for building great F# documentation, samples and blogs";
-        internal const System.String AssemblyVersion = "6.0.5";
-        internal const System.String AssemblyFileVersion = "6.0.5";
-        internal const System.String AssemblyInformationalVersion = "6.0.5";
+        internal const System.String AssemblyVersion = "6.0.6";
+        internal const System.String AssemblyFileVersion = "6.0.6";
+        internal const System.String AssemblyInformationalVersion = "6.0.6";
         internal const System.String AssemblyCopyright = "Apache 2.0 License";
     }
 }

--- a/src/Common/AssemblyInfo.fs
+++ b/src/Common/AssemblyInfo.fs
@@ -4,16 +4,16 @@ open System.Reflection
 
 [<assembly: AssemblyProductAttribute("FSharp.Formatting")>]
 [<assembly: AssemblyDescriptionAttribute("A package of libraries for building great F# documentation, samples and blogs")>]
-[<assembly: AssemblyVersionAttribute("6.0.6")>]
-[<assembly: AssemblyFileVersionAttribute("6.0.6")>]
-[<assembly: AssemblyInformationalVersionAttribute("6.0.6")>]
+[<assembly: AssemblyVersionAttribute("6.0.7")>]
+[<assembly: AssemblyFileVersionAttribute("6.0.7")>]
+[<assembly: AssemblyInformationalVersionAttribute("6.0.7")>]
 [<assembly: AssemblyCopyrightAttribute("Apache 2.0 License")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyProduct = "FSharp.Formatting"
     let [<Literal>] AssemblyDescription = "A package of libraries for building great F# documentation, samples and blogs"
-    let [<Literal>] AssemblyVersion = "6.0.6"
-    let [<Literal>] AssemblyFileVersion = "6.0.6"
-    let [<Literal>] AssemblyInformationalVersion = "6.0.6"
+    let [<Literal>] AssemblyVersion = "6.0.7"
+    let [<Literal>] AssemblyFileVersion = "6.0.7"
+    let [<Literal>] AssemblyInformationalVersion = "6.0.7"
     let [<Literal>] AssemblyCopyright = "Apache 2.0 License"

--- a/src/Common/AssemblyInfo.fs
+++ b/src/Common/AssemblyInfo.fs
@@ -4,16 +4,16 @@ open System.Reflection
 
 [<assembly: AssemblyProductAttribute("FSharp.Formatting")>]
 [<assembly: AssemblyDescriptionAttribute("A package of libraries for building great F# documentation, samples and blogs")>]
-[<assembly: AssemblyVersionAttribute("6.0.5")>]
-[<assembly: AssemblyFileVersionAttribute("6.0.5")>]
-[<assembly: AssemblyInformationalVersionAttribute("6.0.5")>]
+[<assembly: AssemblyVersionAttribute("6.0.6")>]
+[<assembly: AssemblyFileVersionAttribute("6.0.6")>]
+[<assembly: AssemblyInformationalVersionAttribute("6.0.6")>]
 [<assembly: AssemblyCopyrightAttribute("Apache 2.0 License")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyProduct = "FSharp.Formatting"
     let [<Literal>] AssemblyDescription = "A package of libraries for building great F# documentation, samples and blogs"
-    let [<Literal>] AssemblyVersion = "6.0.5"
-    let [<Literal>] AssemblyFileVersion = "6.0.5"
-    let [<Literal>] AssemblyInformationalVersion = "6.0.5"
+    let [<Literal>] AssemblyVersion = "6.0.6"
+    let [<Literal>] AssemblyFileVersion = "6.0.6"
+    let [<Literal>] AssemblyInformationalVersion = "6.0.6"
     let [<Literal>] AssemblyCopyright = "Apache 2.0 License"

--- a/src/FSharp.Formatting.ApiDocs/GenerateHtml.fs
+++ b/src/FSharp.Formatting.ApiDocs/GenerateHtml.fs
@@ -113,9 +113,14 @@ type HtmlRender(markDownComments) =
                           !! "Modifiers: "
                           !! HttpUtility.HtmlEncode(m.FormatModifiers)
                           br []
-                        if not (m.TypeArguments.IsEmpty) then
-                          !!"Type parameters: "
-                          !!m.FormatTypeArguments
+
+                          // We suppress the display of ill-formatted type parameters for places
+                          // where these have not been explicitly declared
+                          match m.FormatTypeArguments with
+                          | None -> ()
+                          | Some v -> 
+                              !!"Type parameters: "
+                              !!v
                       ]
                     ]
                ]

--- a/version.props
+++ b/version.props
@@ -1,8 +1,8 @@
 <Project>
       <PropertyGroup>
-        <Version>6.0.5</Version>
+        <Version>6.0.6</Version>
         <PackageReleaseNotes>
-- improve display in FSharp.Formatting API docs and add more information
+- fix default styling
         </PackageReleaseNotes>
       </PropertyGroup>
     </Project>

--- a/version.props
+++ b/version.props
@@ -1,8 +1,8 @@
 <Project>
       <PropertyGroup>
-        <Version>6.0.6</Version>
+        <Version>6.0.7</Version>
         <PackageReleaseNotes>
-- fix default styling
+- fix formatting of generic parameters so they don&#39;t show inference variables for members
         </PackageReleaseNotes>
       </PropertyGroup>
     </Project>


### PR DESCRIPTION

There were cases where inferred generic parameters were showing through in the output

The correct use of `FSharpType.Prettify` helps with this

