### PR TITLE
put extra content in `extras` directory in nuget package and include Dockerfile and NuGet.config

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+## 6.0.9
+  - put extra content in `extras` directory in nuget package and include Dockerfile and NuGet.config
+
 ## 6.0.8
   - show extended type in generated docs for extension members
   - include fsdocs-styles.css, fsdocs-search.js, fsdocs-tips.js in built site 'content' directory by default

--- a/src/FSharp.Formatting.CommandTool/BuildCommand.fs
+++ b/src/FSharp.Formatting.CommandTool/BuildCommand.fs
@@ -443,22 +443,22 @@ type CoreBuildOptions(watch) =
               else None
 
         let extraInputs =
-           if x.nodefaultcontent then
-              None
-           else
+           [ if not x.nodefaultcontent then
+              // The "content" content goes in "content"
               // This is in-package
-              let attempt1 = Path.GetFullPath(Path.Combine(dir, "..", "..", "..", "styles", "content"))
-              // This is in-repo only
-              let attempt2 = Path.GetFullPath(Path.Combine(dir, "..", "..", "..", "..", "..", "docs", "content"))
+              let attempt1 = Path.GetFullPath(Path.Combine(dir, "..", "..", "..", "extras"))
               if (try Directory.Exists(attempt1) with _ -> false) then
                   printfn "using extra content from %s" attempt1
-                  Some [(attempt1, "content")]
-              elif (try Directory.Exists(attempt2) with _ -> false) then
-                  printfn "using extra content from %s" attempt2
-                  Some [(attempt2, "content")]
-              else
-                  printfn "no extra content found at %s or %s" attempt1 attempt2
-                  None
+                  (attempt1, "content")
+              else 
+                  // This is for in-repo use only
+                  let attempt2 = Path.GetFullPath(Path.Combine(dir, "..", "..", "..", "..", "..", "docs", "content"))
+                  if (try Directory.Exists(attempt2) with _ -> false) then
+                      printfn "using extra content from %s" attempt2
+                      (attempt2, "content")
+                  else
+                      printfn "no extra content found at %s or %s" attempt1 attempt2
+            ]
 
         let runConvert () =
             try
@@ -467,7 +467,7 @@ type CoreBuildOptions(watch) =
                 Literate.ConvertDirectory(
                     x.input,
                     ?htmlTemplate=defaultTemplate,
-                    ?extraInputs = extraInputs,
+                    extraInputs = extraInputs,
                     generateAnchors = true,
                     outputDirectory = output,
                     ?formatAgent = None,

--- a/src/FSharp.Formatting.CommandTool/FSharp.Formatting.CommandTool.fsproj
+++ b/src/FSharp.Formatting.CommandTool/FSharp.Formatting.CommandTool.fsproj
@@ -23,8 +23,10 @@
   <ItemGroup>
     <!-- NuGet package content -->
     <Content Include="..\..\misc\templates\*.html" PackagePath="templates" />
-    <Content Include="..\..\docs\content\*" PackagePath="styles\content" />
-    <Content Include="..\..\docs\content\img\*" PackagePath="styles\img\content" />
+    <Content Include="..\..\docs\Dockerfile" PackagePath="extras" />
+    <Content Include="..\..\docs\NuGet.config" PackagePath="extras" />
+    <Content Include="..\..\docs\content\*" PackagePath="extras\content" />
+    <Content Include="..\..\docs\content\img\*" PackagePath="extras\img\content" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
the `fsdocs` tool now has the right Dockerfile and NuGet.config included by default to help enable notebook support

These may need to be updated.  They can be overriden by individual sites
