### PR TITLE
fix lower case member names spacing

### DIFF
--- a/src/Common/AssemblyInfo.cs
+++ b/src/Common/AssemblyInfo.cs
@@ -4,17 +4,17 @@ using System.Reflection;
 
 [assembly: AssemblyProduct("FSharp.Formatting")]
 [assembly: AssemblyDescription("A package of libraries for building great F# documentation, samples and blogs")]
-[assembly: AssemblyVersion("7.2.3")]
-[assembly: AssemblyFileVersion("7.2.3")]
-[assembly: AssemblyInformationalVersion("7.2.3")]
+[assembly: AssemblyVersion("7.2.4")]
+[assembly: AssemblyFileVersion("7.2.4")]
+[assembly: AssemblyInformationalVersion("7.2.4")]
 [assembly: AssemblyCopyright("Apache 2.0 License")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyProduct = "FSharp.Formatting";
         internal const System.String AssemblyDescription = "A package of libraries for building great F# documentation, samples and blogs";
-        internal const System.String AssemblyVersion = "7.2.3";
-        internal const System.String AssemblyFileVersion = "7.2.3";
-        internal const System.String AssemblyInformationalVersion = "7.2.3";
+        internal const System.String AssemblyVersion = "7.2.4";
+        internal const System.String AssemblyFileVersion = "7.2.4";
+        internal const System.String AssemblyInformationalVersion = "7.2.4";
         internal const System.String AssemblyCopyright = "Apache 2.0 License";
     }
 }

--- a/src/Common/AssemblyInfo.fs
+++ b/src/Common/AssemblyInfo.fs
@@ -4,16 +4,16 @@ open System.Reflection
 
 [<assembly: AssemblyProductAttribute("FSharp.Formatting")>]
 [<assembly: AssemblyDescriptionAttribute("A package of libraries for building great F# documentation, samples and blogs")>]
-[<assembly: AssemblyVersionAttribute("7.2.3")>]
-[<assembly: AssemblyFileVersionAttribute("7.2.3")>]
-[<assembly: AssemblyInformationalVersionAttribute("7.2.3")>]
+[<assembly: AssemblyVersionAttribute("7.2.4")>]
+[<assembly: AssemblyFileVersionAttribute("7.2.4")>]
+[<assembly: AssemblyInformationalVersionAttribute("7.2.4")>]
 [<assembly: AssemblyCopyrightAttribute("Apache 2.0 License")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyProduct = "FSharp.Formatting"
     let [<Literal>] AssemblyDescription = "A package of libraries for building great F# documentation, samples and blogs"
-    let [<Literal>] AssemblyVersion = "7.2.3"
-    let [<Literal>] AssemblyFileVersion = "7.2.3"
-    let [<Literal>] AssemblyInformationalVersion = "7.2.3"
+    let [<Literal>] AssemblyVersion = "7.2.4"
+    let [<Literal>] AssemblyFileVersion = "7.2.4"
+    let [<Literal>] AssemblyInformationalVersion = "7.2.4"
     let [<Literal>] AssemblyCopyright = "Apache 2.0 License"

--- a/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
+++ b/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
@@ -973,7 +973,11 @@ module internal SymbolReader =
           // Indexers
           | _, true, _, "Item" -> span [] [!! "this.["; fullArgUsage; !! "]"]
           // Ordinary instance members
-          | _, true, _, name -> span [] [!! "this."; !! name; fullArgUsage ]
+          | _, true, _, name ->
+              span [] [!! "this.";
+                       !! name;
+                       if preferNoParens then !! "&#32;"
+                       fullArgUsage ]
           // A hack for Array.Parallel.map in FSharp.Core. 
           | _, false, _, name when specialCase1 ->
               span [] [!! ("Array.Parallel." + name); fullArgUsage]
@@ -1063,8 +1067,12 @@ module internal SymbolReader =
                 span [] [fieldsHtmls.[0]; !!"&#32;"; !! nm; fieldsHtmls.[1] ] 
                 |> codeHtml
             else
-                let fieldHtml = fieldsHtmls |> Html.sepWith ",&#32;"
-                span [] [!! nm; !! "("; fieldHtml;  !! ")" ]
+                match fieldsHtmls with
+                | [] -> span [] [!! nm ]
+                | [fieldHtml] -> span [] [!! nm; !!"&#32;"; fieldHtml ]
+                | _ ->
+                    let fieldHtml = fieldsHtmls |> Html.sepWith ",&#32;"
+                    span [] [!! nm; !! "("; fieldHtml;  !! ")" ]
                 |> codeHtml
 
         let paramHtmls =

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 <Project>
       <PropertyGroup>
-        <Version>7.2.3</Version>
+        <Version>7.2.4</Version>
         <PackageReleaseNotes>
 - support `&lt;namespacesummary&gt;...&lt;namespacesummary&gt;`
 - support `&lt;namespaceremarks&gt;...&lt;namespaceremarks&gt;`


### PR DESCRIPTION
From DiffSharp, there was a glitch when member names are lower case:

![image](https://user-images.githubusercontent.com/7204669/89485175-1bd27680-d798-11ea-9b5b-1abfb2bcecc8.png)

This also fixes a mistake in union cases in FSharp.Core where union cases not taking any arguments like `None` were shown as `None()`