### PR TITLE
only use suppress in namespace lists

### DIFF
--- a/src/Common/AssemblyInfo.cs
+++ b/src/Common/AssemblyInfo.cs
@@ -4,17 +4,17 @@ using System.Reflection;
 
 [assembly: AssemblyProduct("FSharp.Formatting")]
 [assembly: AssemblyDescription("A package of libraries for building great F# documentation, samples and blogs")]
-[assembly: AssemblyVersion("7.2.4")]
-[assembly: AssemblyFileVersion("7.2.4")]
-[assembly: AssemblyInformationalVersion("7.2.4")]
+[assembly: AssemblyVersion("7.2.5")]
+[assembly: AssemblyFileVersion("7.2.5")]
+[assembly: AssemblyInformationalVersion("7.2.5")]
 [assembly: AssemblyCopyright("Apache 2.0 License")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyProduct = "FSharp.Formatting";
         internal const System.String AssemblyDescription = "A package of libraries for building great F# documentation, samples and blogs";
-        internal const System.String AssemblyVersion = "7.2.4";
-        internal const System.String AssemblyFileVersion = "7.2.4";
-        internal const System.String AssemblyInformationalVersion = "7.2.4";
+        internal const System.String AssemblyVersion = "7.2.5";
+        internal const System.String AssemblyFileVersion = "7.2.5";
+        internal const System.String AssemblyInformationalVersion = "7.2.5";
         internal const System.String AssemblyCopyright = "Apache 2.0 License";
     }
 }

--- a/src/Common/AssemblyInfo.fs
+++ b/src/Common/AssemblyInfo.fs
@@ -4,16 +4,16 @@ open System.Reflection
 
 [<assembly: AssemblyProductAttribute("FSharp.Formatting")>]
 [<assembly: AssemblyDescriptionAttribute("A package of libraries for building great F# documentation, samples and blogs")>]
-[<assembly: AssemblyVersionAttribute("7.2.4")>]
-[<assembly: AssemblyFileVersionAttribute("7.2.4")>]
-[<assembly: AssemblyInformationalVersionAttribute("7.2.4")>]
+[<assembly: AssemblyVersionAttribute("7.2.5")>]
+[<assembly: AssemblyFileVersionAttribute("7.2.5")>]
+[<assembly: AssemblyInformationalVersionAttribute("7.2.5")>]
 [<assembly: AssemblyCopyrightAttribute("Apache 2.0 License")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyProduct = "FSharp.Formatting"
     let [<Literal>] AssemblyDescription = "A package of libraries for building great F# documentation, samples and blogs"
-    let [<Literal>] AssemblyVersion = "7.2.4"
-    let [<Literal>] AssemblyFileVersion = "7.2.4"
-    let [<Literal>] AssemblyInformationalVersion = "7.2.4"
+    let [<Literal>] AssemblyVersion = "7.2.5"
+    let [<Literal>] AssemblyFileVersion = "7.2.5"
+    let [<Literal>] AssemblyInformationalVersion = "7.2.5"
     let [<Literal>] AssemblyCopyright = "Apache 2.0 License"

--- a/version.props
+++ b/version.props
@@ -1,14 +1,9 @@
 <Project>
       <PropertyGroup>
-        <Version>7.2.4</Version>
+        <Version>7.2.5</Version>
         <PackageReleaseNotes>
-- support `&lt;namespacesummary&gt;...&lt;namespacesummary&gt;`
-- support `&lt;namespaceremarks&gt;...&lt;namespaceremarks&gt;`
-- support `&lt;note&gt;...&lt;note&gt;`
-- support `&lt;exclude /&gt;`
-- allow  `&lt;a href=&quot;...&quot; &gt;` in XML doc comments
-- allow  `&lt;paramref name=&quot;...&quot; &gt;` in XML doc comments
-- document XML doc things supported
+- change `&lt;namespacesummary&gt;...&lt;namespacesummary&gt;` to `&lt;namespacedoc&gt; &lt;summary&gt;... &lt;/summary&gt; &lt;/namespacedoc&gt;`
+- change `&lt;categoryindex&gt;3&lt;categoryindex&gt;` to `&lt;category index=&quot;3&quot;&gt;...&lt;/category&gt;`
         </PackageReleaseNotes>
       </PropertyGroup>
     </Project>


### PR DESCRIPTION
There are a small set of bespoke suppressions active for FSHarp.Core doc generation - these can gradually be moved to use `<exclude />` - however there was a bug where these were suppressing entire content of some namespaces
