### PR TITLE
Style update: Add some top padding to masthead h3

### DIFF
--- a/docs/content/fsdocs-default.css
+++ b/docs/content/fsdocs-default.css
@@ -31,6 +31,7 @@ body {
     }
 
     .masthead h3 {
+        margin-top: 15px;
         margin-bottom: 5px;
         font-size: 170%;
     }


### PR DESCRIPTION
With this change:

![image](https://user-images.githubusercontent.com/6309070/91219826-21a0e500-e6d0-11ea-984b-b6f39afb9342.png)

Before this change:

![image](https://user-images.githubusercontent.com/6309070/91219847-282f5c80-e6d0-11ea-83f9-9b6667bba0b5.png)
