### PR TITLE
Add include-it-raw literate command

### DIFF
--- a/docs/literate.fsx
+++ b/docs/literate.fsx
@@ -64,6 +64,7 @@ The F# script files is processed as follows:
 |   `(*** include-fsi-output ***)`       | The F# Interactive output of the preceeding snippet   |
 |   `(*** include-fsi-merged-output ***)`       | The merge of console output and F# Interactive output of the preceeding snippet   |
 |   `(*** include-it ***)`       | The formatted result of the preceeding snippet |
+|   `(*** include-it-raw ***)`       | The unformatted result of the preceeding snippet |
 |   `(*** include-value: value-name ***)`       | The formatted value  |
 |   `(*** raw ***)`       | The subsequent code is treated as raw text |
 
@@ -82,6 +83,7 @@ F# language.
 |   `(*** include-fsi-output: snippet-name ***)`       | The F# Interactive output of the named snippet  |
 |   `(*** include-fsi-merged-output: snippet-name ***)`       | The merge of console output and F# Interactive output of the named snippet  |
 |   `(*** include-it: snippet-name ***)`       | The formatted result of the named snippet  |
+|   `(*** include-it-raw: snippet-name ***)`       | The unformatted result of the named snippet  |
 |   `(*** include: snippet-name ***)`       | Include the code of the named snippet |
 
 #### Hiding code snippets

--- a/src/FSharp.Formatting.Literate/Document.fs
+++ b/src/FSharp.Formatting.Literate/Document.fs
@@ -67,6 +67,10 @@ type LiterateParagraph =
   /// (*** include-it:foo ***) - Include "it" value from a named snippet
   | ItValueReference of string * LiterateParagraphOptions
 
+  /// (*** include-it-raw ***) - Include "it" value from the subsequent snippet here as raw text (Not formatted as fsi)
+  /// (*** include-it-raw:foo ***) - Include "it" value from a named snippet as raw text (Not formatted as fsi)
+  | ItRawReference of string * LiterateParagraphOptions
+
   /// (*** include-value:foo ***) - Include the formatting of a specified value here
   | ValueReference of string * LiterateParagraphOptions
 
@@ -86,6 +90,7 @@ type LiterateParagraph =
     | FsiOutputReference(_,popts) -> popts
     | OutputReference(_,popts) -> popts
     | ItValueReference(_,popts) -> popts
+    | ItRawReference(_,popts) -> popts
     | ValueReference(_,popts) -> popts
     | LiterateCode(_,_,popts) -> popts
     | LanguageTaggedCode(_,_,popts) -> popts

--- a/src/FSharp.Formatting.Literate/ParseScript.fs
+++ b/src/FSharp.Formatting.Literate/ParseScript.fs
@@ -194,6 +194,18 @@ type internal ParseScript(parseOptions, ctx:CompilerContext) =
         let p = EmbedParagraphs(ItValueReference(ref, popts), None)
         transformBlocks None count noEval (p::acc) defs blocks
 
+    // Include unformatted 'it' of previous block
+    | BlockCommand((Command "include-it-raw" "") as cmds)::blocks when prevCodeId.IsSome -> 
+        let popts = getParaOptions cmds
+        let p1 = EmbedParagraphs(ItRawReference(prevCodeId.Value, popts), None)
+        transformBlocks prevCodeId count noEval (p1::acc) defs blocks
+
+    // Include unformatted 'it' of a named block
+    | BlockCommand(Command "include-it-raw" ref as cmds)::blocks -> 
+        let popts = getParaOptions cmds
+        let p = EmbedParagraphs(ItRawReference(ref, popts), None)
+        transformBlocks None count noEval (p::acc) defs blocks
+
     // Include formatted named value 
     | BlockCommand(Command "include-value" ref as cmds)::blocks -> 
         let popts = getParaOptions cmds

--- a/src/FSharp.Formatting.Literate/Transformations.fs
+++ b/src/FSharp.Formatting.Literate/Transformations.fs
@@ -295,6 +295,7 @@ module internal Transformations =
       | FsiOutputReference (ref, _popts)
       | OutputReference (ref, _popts)
       | ItValueReference (ref, _popts)
+      | ItRawReference (ref, _popts)
       | ValueReference (ref, _popts) ->
         let key = (match special with ValueReference _ -> ValueRef ref | _ -> OutputRef ref)
         match results.TryFind(key) with
@@ -305,6 +306,7 @@ module internal Transformations =
             | FsiOutputReference _ -> FsiEmbedKind.FsiOutput
             | OutputReference _ -> FsiEmbedKind.ConsoleOutput
             | ItValueReference _ -> FsiEmbedKind.ItValue
+            | ItRawReference _ -> FsiEmbedKind.ItRaw
             | ValueReference _ -> FsiEmbedKind.Value
             | _ -> failwith "unreachable"
           ctx.Evaluator.Value.Format(result, kind, executionCount)
@@ -385,6 +387,7 @@ module internal Transformations =
         | FsiOutputReference _
         | OutputReference _
         | ItValueReference _
+        | ItRawReference _
         | ValueReference _ ->
             let msg = "Warning: Output, it-value and value references require --eval" 
             printfn "%s" msg

--- a/tests/FSharp.Literate.Tests/EvalTests.fs
+++ b/tests/FSharp.Literate.Tests/EvalTests.fs
@@ -349,6 +349,20 @@ let ``Can hide and include-it`` () =
   html1 |> shouldNotContainText "1000"
 
 [<Test>]
+let ``Can hide and include-it-raw`` () =
+  let content = """
+1000+1000
+|> string
+(*** include-it-raw ***)
+"""
+  let fsie = getFsiEvaluator()
+  let doc1 = Literate.ParseScriptString(content, "." </> "A.fsx", formatAgent=getFormatAgent(), fsiEvaluator = fsie)
+  let html1 = Literate.ToHtml(doc1)
+  html1 |> shouldContainText "2000"
+  html1 |> shouldNotContainText "\"2000\""
+  html1 |> shouldNotContainText "<code>2000</code>"
+
+[<Test>]
 let ``Can include-output`` () =
   let content = """
 printfn "%sworld" "hello"


### PR DESCRIPTION
This pull request addresses issue #611. 

The idea is to have a way to include `results of snippets` not formatted as fsi output but just as `plain text`. This allows for formatting them as `html`, e.g. as `charts`, as can be seen [here](https://fslab.org/FSharp.Stats/Covariance.html). In the example, this was done by using a `custom evalutator`, which is not feasible with the `fsdocs tool`.

Therefore I added a new literate command `include-it-raw`, which evaluates the snippet, but then inserts is as plain text. As a small example I used this to embed a `html table` from a jagged array:

![IncludeItRaw](https://user-images.githubusercontent.com/17880410/102715756-d42c3180-42d7-11eb-8dd2-cfa9f8423168.png)

The code in the `Evaluator.fs` got a little bit messy, as `string`s are formatted surrounded by `"`s, which show up in the final document and might even hinder the correct html formatting. I remove them in the `Evaluator.Format` method but maybe you have a better place or idea?

