### PR TITLE
Prevent CLI parameters from being discarded

### DIFF
--- a/src/FSharp.Formatting.CommandTool/ProjectCracker.fs
+++ b/src/FSharp.Formatting.CommandTool/ProjectCracker.fs
@@ -402,7 +402,7 @@ module Crack =
         let parametersForProjectInfo (info: CrackedProjectInfo) =
             let projectUrl = info.PackageProjectUrl |> Option.map ensureTrailingSlash |> Option.defaultValue root
             let repoUrl = info.RepositoryUrl |> Option.map ensureTrailingSlash
-            userParameters @ List.choose id [
+            List.choose id [
                 param None ParamKeys.``root`` (Some root)
                 param None ParamKeys.``fsdocs-authors`` (Some (info.Authors |> Option.defaultValue ""))
                 param None ParamKeys.``fsdocs-collection-name`` (Some collectionName)
@@ -422,7 +422,7 @@ module Crack =
                 param (Some "<RepositoryUrl>") ParamKeys.``fsdocs-repository-link`` repoUrl
                 param None ParamKeys.``fsdocs-repository-branch`` info.RepositoryBranch
                 param None ParamKeys.``fsdocs-repository-commit`` info.RepositoryCommit
-            ]
+            ] @ userParameters
 
         let crackedProjects =
             projectInfos


### PR DESCRIPTION
Fixes #633 

This took a little while to hunt down. But, basically, the logic is:

1. Accumulate parameters from multiple sources
2. Rely on FSharp.Core's `dict` and `readOnlyDict` to de-duplicate values

The limitation of the above approach is that it is _order dependent_. This isn't bad, per se. But it means step one above needs to be handled carefully. So, this patch just changes the order in which things are accumulated (putting the `userParameters` at the _end_ of the list).
