### PR TITLE
Fix default styles to show examples and strings more clearly

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+## 9.0.2
+* Fix default styles to show examples and strings more clearly
+
 ## 9.0.1
 * Proper fix for elide multi-language docs from navigation and site search index
 

--- a/docs/content/fsdocs-default.css
+++ b/docs/content/fsdocs-default.css
@@ -309,7 +309,7 @@ body {
     background-color: #212d30;
     padding: 10px;
     border-radius: 5px;
-    color: #d1d1d1;
+    color: #8e0e2b;
     max-width: none;
 }
 
@@ -426,7 +426,7 @@ body {
 }
 /* strings --- and stlyes for other string related formats */
 #fsdocs-content span.s {
-    color: #E0E268;
+    color: #771212;
 }
 /* printf formatters */
 #fsdocs-content span.pf {

--- a/src/FSharp.Formatting.Literate/Literate.fs
+++ b/src/FSharp.Formatting.Literate/Literate.fs
@@ -122,7 +122,8 @@ type Literate private () =
     |> Transformations.formatCodeSnippets path ctx
     |> Transformations.evaluateCodeSnippets ctx
 
-  /// Parse Markdown document
+  /// <summary>Parse Markdown document</summary>
+
   static member ParseMarkdownString
     (content, ?path, ?formatAgent, ?fscOptions, ?definedSymbols, ?references, ?fsiEvaluator, ?parseOptions) =
     let ctx = parsingContext formatAgent fsiEvaluator fscOptions definedSymbols

--- a/src/FSharp.Formatting.Markdown/Markdown.fs
+++ b/src/FSharp.Formatting.Markdown/Markdown.fs
@@ -77,8 +77,15 @@ type Markdown =
     Markdown.WriteHtml(doc, wr, ?newline=newline)
     sb.ToString()
 
-  /// Transform Markdown document into HTML format. 
-  /// The result will be returned as a string.
+  /// <summary>
+  ///  Transform Markdown document into HTML format. 
+  ///  The result will be returned as a string.
+  /// </summary>
+  /// <example>
+  ///   <code>
+  ///     let html = Markdown.ToHtml("# Heading")
+  ///   </code>
+  /// </example>
   static member ToHtml(markdownText: string, ?newline) =
     let doc = Markdown.Parse(markdownText, ?newline=newline)
     Markdown.ToHtml(doc, ?newline=newline)


### PR DESCRIPTION
There are some glitches in the CSS defaults:

1. Examples not shown in clearly contrasted font:

![image](https://user-images.githubusercontent.com/7204669/112234779-25c8bd00-8c35-11eb-8cfe-8164cfe09d50.png)

2. Strings not shown in clearly visible font:

![image](https://user-images.githubusercontent.com/7204669/112234828-42fd8b80-8c35-11eb-9d73-4140849e0c4a.png)
