### PR TITLE
Make Process.Start failure non fatal for browser start

### DIFF
--- a/src/FSharp.Formatting.CommandTool/BuildCommand.fs
+++ b/src/FSharp.Formatting.CommandTool/BuildCommand.fs
@@ -813,7 +813,10 @@ type CoreBuildOptions(watch) =
             if not this.nolaunch_option then
                 let url = sprintf "http://localhost:%d/%s" this.port_option this.open_option
                 printfn "launching browser window to open %s" url
-                Process.Start(new ProcessStartInfo(url, UseShellExecute = true)) |> ignore
+                try
+                    Process.Start(new ProcessStartInfo(url, UseShellExecute = true)) |> ignore
+                with ex ->
+                    printfn "Warning, unable to launch browser(%s), try manually browsing to %s" ex.Message url
             waitForKey watch
 
         if ok then 0 else 1


### PR DESCRIPTION
Handle exceptions: https://github.com/fsprojects/FSharp.Formatting/issues/650

I couldn't find a good spot to put CLI related integration test cases into the project.