### PR TITLE
Use h2 for type and module page titles

### DIFF
--- a/src/FSharp.Formatting.ApiDocs/GenerateHtml.fs
+++ b/src/FSharp.Formatting.ApiDocs/GenerateHtml.fs
@@ -224,7 +224,7 @@ type HtmlRender(model: ApiDocModel) =
         | Some m when m.RequiresQualifiedAccess -> m.Name + "." + entity.Name
         | _ -> entity.Name
 
-    [ h1 [] [!! (usageName + (if entity.IsTypeDefinition then " Type" else " Module")) ]
+    [ h2 [] [!! (usageName + (if entity.IsTypeDefinition then " Type" else " Module")) ]
       p [] [!! "Namespace: "; a [Href (info.Namespace.Url(root, collectionName, qualify, model.FileExtensions.InUrl))] [!!info.Namespace .Name]]
       p [] [!! ("Assembly: " + entity.Assembly.Name + ".dll")]
 

--- a/src/FSharp.Formatting.ApiDocs/GenerateMarkdown.fs
+++ b/src/FSharp.Formatting.ApiDocs/GenerateMarkdown.fs
@@ -164,7 +164,7 @@ type MarkdownRender(model: ApiDocModel) =
         | _ -> entity.Name
 
     [ 
-      ``#`` [!! (usageName + (if entity.IsTypeDefinition then " Type" else " Module"))]
+      ``##`` [!! (usageName + (if entity.IsTypeDefinition then " Type" else " Module"))]
       p [
         !! "Namespace: "
         link [!! info.Namespace.Name] (info.Namespace.Url(root, collectionName, qualify, model.FileExtensions.InUrl))


### PR DESCRIPTION
I would like to submit this change to make documentation consistent between titles for namespaces (currently uses h2) and types and modules (currently uses h1). This PR makes both titles use h2.

I think h2 is better because in the default style it doesn't do allcaps so we retain the correct spelling of types and modules.

h2 example (good)
![image](https://user-images.githubusercontent.com/5365982/113434536-0cfc9c00-93d9-11eb-9bd3-69c7076a1aad.png)

h1 example (bad)
![image](https://user-images.githubusercontent.com/5365982/113434587-2271c600-93d9-11eb-81c5-0cecedac1cba.png)
