### PR TITLE
frontmatter in literate scripts and markdown

### DIFF
--- a/FSharp.Formatting.sln
+++ b/FSharp.Formatting.sln
@@ -29,7 +29,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{312E452A-1
 		docs\codeformat.fsx = docs\codeformat.fsx
 		docs\commandline.md = docs\commandline.md
 		docs\content.fsx = docs\content.fsx
-		docs\diagnostics.md = docs\diagnostics.md
 		docs\evaluation.fsx = docs\evaluation.fsx
 		docs\index.md = docs\index.md
 		docs\literate.fsx = docs\literate.fsx

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+## 11.1.0
+* Add frontmatter, category, categoryindex, index, title
+
 ## 11.0.4
 * testing package publish
 

--- a/docs/apidocs.fsx
+++ b/docs/apidocs.fsx
@@ -1,3 +1,11 @@
+(**
+---
+title: Generating API Docs
+category: Documentation
+categoryindex: 1
+index: 5
+---
+*)
 (*** condition: prepare ***)
 #nowarn "211"
 #I "../src/FSharp.Formatting/bin/Release/netstandard2.1"
@@ -22,7 +30,7 @@ let root = "C:\\"
 [![Script](img/badge-script.svg)]({{fsdocs-source-basename}}.fsx)&emsp;
 [![Notebook](img/badge-notebook.svg)]({{fsdocs-source-basename}}.ipynb)
 
-API Docs
+API Documentation Generation
 ====================================
 
 The [command-line tool `fsdocs`](commandline.html) can be used to generate documentation 

--- a/docs/codeformat.fsx
+++ b/docs/codeformat.fsx
@@ -1,3 +1,10 @@
+(**
+---
+category: Advanced
+categoryindex: 3
+index: 1
+---
+*)
 (*** condition: prepare ***)
 #nowarn "211"
 #I "../src/FSharp.Formatting/bin/Release/netstandard2.1"
@@ -22,7 +29,7 @@
 Code formatting
 ==============================
 
-This page demonstrates how to use `FSharp.Formatting.CodeFormat.dll` to tokenize 
+This page demonstrates how to use `FSharp.Formatting.CodeFormat` to tokenize 
 F# source code, obtain information about the source code (mainly tooltips
 from the type-checker) and how to turn the code into a nicely formatted HTML.
 

--- a/docs/commandline.md
+++ b/docs/commandline.md
@@ -1,4 +1,9 @@
-﻿# Command line
+﻿---
+category: Documentation
+categoryindex: 1
+index: 1
+---
+# Command line
 
 To use F# Formatting tools via the command line, you can use the `fsdocs` dotnet tool.
 

--- a/docs/content.fsx
+++ b/docs/content.fsx
@@ -1,3 +1,10 @@
+(**
+---
+category: Documentation
+categoryindex: 1
+index: 3
+---
+*)
 (*** condition: prepare ***)
 #nowarn "211"
 #I "../src/FSharp.Formatting/bin/Release/netstandard2.1"
@@ -60,6 +67,37 @@ copy of this content in your `content` directory.
 ## Ignored Content
 
 Any file or directory beginning with `.` is ignored.
+
+## Front matter
+
+Each content file can have frontmatter.  This determines the navigation bar title, categorization and ordering.
+
+For markdown, the format is:
+```
+---
+title: Some Title
+category: Some Category
+categoryindex: 2
+index: 3
+---
+```
+For F# scripts the frontmatter is in this form:
+```fsharp
+(**
+---
+title: Literate Script
+category: Examples
+categoryindex: 2
+index: 1
+---
+*)
+```
+All entries are optional and the frontmatter is optional.
+The `categoryindex` determines the ordering of categories.
+The `index` determines the ordering of within each category.
+The `title` is used in the navigation bar instead of any title inferred from the document.
+
+
 
 ## Multi-language Content
 

--- a/docs/content.fsx
+++ b/docs/content.fsx
@@ -70,7 +70,7 @@ Any file or directory beginning with `.` is ignored.
 
 ## Front matter
 
-Each content file can have frontmatter.  This determines the navigation bar title, categorization and ordering.
+Each content file can have optional frontmatter.  This determines the navigation bar title, categorization and ordering.
 
 For markdown, the format is:
 ```
@@ -82,17 +82,17 @@ index: 3
 ---
 ```
 For F# scripts the frontmatter is in this form:
-```fsharp
-(**
----
-title: Literate Script
-category: Examples
-categoryindex: 2
-index: 1
----
-*)
-```
-All entries are optional and the frontmatter is optional.
+
+    (**
+    ---
+    title: A Literate Script
+    category: Examples
+    categoryindex: 2
+    index: 1
+    ---
+    *)
+
+All entries are optional.
 The `categoryindex` determines the ordering of categories.
 The `index` determines the ordering of within each category.
 The `title` is used in the navigation bar instead of any title inferred from the document.

--- a/docs/evaluation.fsx
+++ b/docs/evaluation.fsx
@@ -1,3 +1,10 @@
+(**
+---
+category: Documentation
+categoryindex: 1
+index: 6
+---
+*)
 (*** condition: prepare ***)
 #nowarn "211"
 #I "../src/FSharp.Formatting/bin/Release/netstandard2.1"

--- a/docs/literate.fsx
+++ b/docs/literate.fsx
@@ -1,3 +1,10 @@
+(**
+---
+category: Documentation
+categoryindex: 1
+index: 3
+---
+*)
 (*** condition: prepare ***)
 #nowarn "211"
 #I "../src/FSharp.Formatting/bin/Release/netstandard2.1"

--- a/docs/markdown.fsx
+++ b/docs/markdown.fsx
@@ -1,3 +1,10 @@
+(**
+---
+category: Advanced
+categoryindex: 3
+index: 2
+---
+*)
 (*** condition: prepare ***)
 #I "../src/FSharp.Formatting/bin/Release/netstandard2.1"
 #r "FSharp.Formatting.Common.dll"
@@ -20,7 +27,7 @@
 Markdown parser
 ==============================
 
-This page demonstrates how to use `FSharp.Formatting.Markdown.dll` to parse a Markdown
+This page demonstrates how to use `FSharp.Formatting.Markdown` to parse a Markdown
 document, process the obtained document representation and
 how to turn the code into a nicely formatted HTML.
 

--- a/docs/sidebyside/sideextensions.md
+++ b/docs/sidebyside/sideextensions.md
@@ -1,4 +1,10 @@
-﻿Example: LaTeX
+﻿---
+title: Markdown LaTeX
+category: Examples
+categoryindex: 2
+index: 3
+---
+Example: Using the Markdown Extensions for LaTeX
 ===================
 
 To use LaTex extension, you need add javascript

--- a/docs/sidebyside/sidemarkdown.md
+++ b/docs/sidebyside/sidemarkdown.md
@@ -1,4 +1,10 @@
-﻿# Example: Markdown
+﻿---
+title: Markdown Content
+category: Examples
+categoryindex: 2
+index: 2
+---
+# Example: Using Markdown Content
 
 This file demonstrates how to write Markdown document with 
 embedded F# snippets that can be transformed into nice HTML 

--- a/docs/sidebyside/sidescript.fsx
+++ b/docs/sidebyside/sidescript.fsx
@@ -1,5 +1,11 @@
 (**
-# Example: Script
+---
+title: Literate Script
+category: Examples
+categoryindex: 2
+index: 1
+---
+# Example: Using Literate Script Content
 
 This file demonstrates how to write literate F# script
 files (`*.fsx`) that can be transformed into nice HTML

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -1,3 +1,8 @@
+---
+category: Documentation
+categoryindex: 1
+index: 7
+---
 # Customization and Styling 
 
 When using `fsdocs`, there are six levels of extra content development and styling.

--- a/docs/templates/leftside/styling.md
+++ b/docs/templates/leftside/styling.md
@@ -1,6 +1,11 @@
-﻿
-Example: Right-Side NavBar
-==================================
+﻿---
+# Example: Right-Side NavBar
+category: Examples
+categoryindex: 2
+index: 4
+---
+
+# Example: Styling for Right-Side Navigation Bar
 
 The sidebar can be moved to the right by using 
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -1,4 +1,8 @@
-
+---
+category: Advanced
+categoryindex: 3
+index: 1
+---
 
 # Upgrading to fsdocs
 

--- a/src/FSharp.Formatting.Literate/Contexts.fs
+++ b/src/FSharp.Formatting.Literate/Contexts.fs
@@ -49,7 +49,7 @@ type OutputKind =
 /// Defines the output of processing a literate doc
 type internal LiterateDocModel =
   {
-     /// The extracted title of the document (first h1 header)
+     /// The extracted title of the document (first h1 header if not in front matter)
      Title: string
 
      /// The replacement paramaters
@@ -57,6 +57,15 @@ type internal LiterateDocModel =
 
      /// The text for search index generation (empty for notebooks and latex)
      IndexText: string option
+
+     /// The category in the front matter
+     Category: string option
+
+     /// The category index in the front matter (determines the order of categories)
+     CategoryIndex: string option
+
+     /// The index in the front matter (Determines the order of files within a category)
+     Index: string option
 
      /// The relative output path 
      OutputPath: string

--- a/src/FSharp.Formatting.Literate/Literate.fs
+++ b/src/FSharp.Formatting.Literate/Literate.fs
@@ -99,7 +99,7 @@ type Literate private () =
 
         doc.With(paragraphs = pars)
 
-  /// Parse F# Script file
+  /// Parse F# Script file to LiterateDocument
   static member ParseAndCheckScriptFile (path: string, ?formatAgent, ?fscOptions, ?definedSymbols, ?references, ?fsiEvaluator, ?parseOptions, ?rootInputFolder) =
     let ctx = parsingContext formatAgent fsiEvaluator fscOptions definedSymbols
     let rootInputFolder = Some (defaultArg rootInputFolder (Path.GetDirectoryName(path)))
@@ -108,7 +108,7 @@ type Literate private () =
     |> Transformations.formatCodeSnippets path ctx
     |> Transformations.evaluateCodeSnippets ctx
 
-  /// Parse F# Script file
+  /// Parse string as F# Script to LiterateDocument
   static member ParseScriptString (content, ?path, ?formatAgent, ?fscOptions, ?definedSymbols, ?references, ?fsiEvaluator, ?parseOptions, ?rootInputFolder) =
     let ctx = parsingContext formatAgent fsiEvaluator fscOptions definedSymbols
     let filePath =
@@ -123,7 +123,17 @@ type Literate private () =
     |> Transformations.formatCodeSnippets filePath ctx
     |> Transformations.evaluateCodeSnippets ctx
 
-  /// Parse Markdown document
+  /// <summary>
+  ///  Parse Markdown document to LiterateDocument
+  /// </summary>
+  /// <param name="path"></param>
+  /// <param name="formatAgent"></param>
+  /// <param name="fscOptions"></param>
+  /// <param name="definedSymbols"></param>
+  /// <param name="references"></param>
+  /// <param name="fsiEvaluator"></param>
+  /// <param name="parseOptions">Defaults to MarkdownParseOptions.AllowYamlFrontMatter</param>
+  /// <param name="rootInputFolder"></param>
   static member ParseMarkdownFile(path: string, ?formatAgent, ?fscOptions, ?definedSymbols, ?references, ?fsiEvaluator, ?parseOptions, ?rootInputFolder) =
     let ctx = parsingContext formatAgent fsiEvaluator fscOptions definedSymbols
     let rootInputFolder = Some (defaultArg rootInputFolder (Path.GetDirectoryName(path)))
@@ -132,7 +142,18 @@ type Literate private () =
     |> Transformations.formatCodeSnippets path ctx
     |> Transformations.evaluateCodeSnippets ctx
 
-  /// Parse Markdown document
+  /// <summary>
+  ///  Parse string as a markdown document
+  /// </summary>
+  /// <param name="content"></param>
+  /// <param name="path">optional file path for debugging purposes</param>
+  /// <param name="formatAgent"></param>
+  /// <param name="fscOptions"></param>
+  /// <param name="definedSymbols"></param>
+  /// <param name="references"></param>
+  /// <param name="fsiEvaluator"></param>
+  /// <param name="parseOptions">Defaults to MarkdownParseOptions.AllowYamlFrontMatter</param>
+  /// <param name="rootInputFolder"></param>
   static member ParseMarkdownString (content, ?path, ?formatAgent, ?fscOptions, ?definedSymbols, ?references, ?fsiEvaluator, ?parseOptions, ?rootInputFolder) =
     let ctx = parsingContext formatAgent fsiEvaluator fscOptions definedSymbols
     let filePath =
@@ -212,15 +233,17 @@ type Literate private () =
   static member internal ParseAndTransformMarkdownFile
     (input, ?output, ?outputKind, ?formatAgent, ?prefix, ?fscOptions,
       ?lineNumbers, ?references, ?substitutions, ?generateAnchors,
-      ?customizeDocument, ?tokenKindToCss, ?imageSaver, ?rootInputFolder, ?crefResolver) =
+      ?customizeDocument, ?tokenKindToCss, ?imageSaver, ?rootInputFolder,
+      ?crefResolver, ?parseOptions) =
 
     let crefResolver = defaultArg crefResolver (fun _ -> None)
     let outputKind = defaultArg outputKind OutputKind.Html
+    let parseOptions = defaultArg parseOptions MarkdownParseOptions.AllowYamlFrontMatter
     let parseOptions =
         match outputKind with
         | OutputKind.Fsx 
-        | OutputKind.Pynb -> MarkdownParseOptions.ParseCodeAsOther ||| MarkdownParseOptions.ParseNonCodeAsOther
-        | _ -> MarkdownParseOptions.None
+        | OutputKind.Pynb -> parseOptions ||| MarkdownParseOptions.ParseCodeAsOther ||| MarkdownParseOptions.ParseNonCodeAsOther
+        | _ -> parseOptions
 
     let doc = Literate.ParseMarkdownFile (input, ?formatAgent=formatAgent, ?fscOptions=fscOptions, ?references=references, parseOptions=parseOptions, ?rootInputFolder=rootInputFolder)
     let ctx = formattingContext outputKind prefix lineNumbers generateAnchors substitutions tokenKindToCss crefResolver

--- a/src/FSharp.Formatting.Literate/ParseMarkdown.fs
+++ b/src/FSharp.Formatting.Literate/ParseMarkdown.fs
@@ -6,6 +6,6 @@ module internal ParseMarkdown =
   /// Parse the specified Markdown document and return it
   /// as LiterateDocument (without processing code snippets)
   let parseMarkdown filePath rootInputFolder text parseOptions =
-    let parseOptions = defaultArg parseOptions MarkdownParseOptions.None
+    let parseOptions = defaultArg parseOptions MarkdownParseOptions.AllowYamlFrontMatter
     let doc = Markdown.Parse(text, parseOptions=parseOptions)
     LiterateDocument(doc.Paragraphs, "", doc.DefinedLinks, LiterateSource.Markdown text, filePath, rootInputFolder, [| |])

--- a/src/FSharp.Formatting.Markdown/HtmlFormatting.fs
+++ b/src/FSharp.Formatting.Markdown/HtmlFormatting.fs
@@ -276,6 +276,7 @@ let rec internal formatParagraph (ctx:FormattingContext) paragraph =
       for (code, _) in lines do
           ctx.Writer.Write(htmlEncode code)
       ctx.Writer.Write("</code></pre>")
+  | YamlFrontmatter (lines, _) -> ()
   ctx.LineBreak()
 
 /// Write a list of MarkdownParagraph values to a TextWriter

--- a/src/FSharp.Formatting.Markdown/LatexFormatting.fs
+++ b/src/FSharp.Formatting.Markdown/LatexFormatting.fs
@@ -217,6 +217,7 @@ let rec formatParagraph (ctx:FormattingContext) paragraph =
       ctx.LineBreak()
       ctx.Writer.Write(@"\end{lstlisting}")
       ctx.LineBreak()
+  | YamlFrontmatter (lines, _) -> ()
   ctx.LineBreak()
 
 /// Write a list of MarkdownParagraph values to a TextWriter

--- a/src/FSharp.Formatting.Markdown/Markdown.fs
+++ b/src/FSharp.Formatting.Markdown/Markdown.fs
@@ -50,6 +50,7 @@ type Markdown internal () =
     //let (Lines.TrimBlank lines) = lines
     let ctx : ParsingContext =
         { Newline = newline
+          IsFirst = true
           Links = links
           CurrentRange = Some(MarkdownRange.zero)
           ParseOptions=parseOptions }

--- a/src/FSharp.Formatting.Markdown/MarkdownModel.fs
+++ b/src/FSharp.Formatting.Markdown/MarkdownModel.fs
@@ -87,6 +87,9 @@ type MarkdownParagraph =
   /// A special addition for computing paragraphs
   | EmbedParagraphs of customParagraphs:MarkdownEmbedParagraphs * range:MarkdownRange option
 
+  /// A special addition for YAML-style frontmatter
+  | YamlFrontmatter of yaml: string list * range:MarkdownRange option
+
   /// A special addition for inserted outputs
   | OutputBlock of output:string * kind: string * executionCount: int option 
 
@@ -171,6 +174,7 @@ module MarkdownPatterns =
     | InlineHtmlBlock _ 
     | EmbedParagraphs _
     | LatexBlock _
+    | YamlFrontmatter _
     | HorizontalRule _ ->
         ParagraphLeaf(PL par)
     | ListBlock(_, pars, _) ->
@@ -213,4 +217,5 @@ type MarkdownParseOptions =
   | None = 0
   | ParseCodeAsOther = 1
   | ParseNonCodeAsOther = 2
+  | AllowYamlFrontMatter = 4
 

--- a/src/FSharp.Formatting.Markdown/MarkdownUtils.fs
+++ b/src/FSharp.Formatting.Markdown/MarkdownUtils.fs
@@ -221,6 +221,8 @@ module internal MarkdownUtils =
             LatexBlock (env, List.map (mapText f) body, range)
         | HorizontalRule (character, range) ->
             HorizontalRule (character, range)
+        | YamlFrontmatter (lines, range) ->
+            YamlFrontmatter (List.map (mapText f) lines, range)
         | TableBlock (headers, alignments, rows, range) ->
             TableBlock (Option.map (List.map (mapParagraphs f)) headers,
                 alignments,

--- a/tests/FSharp.Literate.Tests/LiterateTests.fs
+++ b/tests/FSharp.Literate.Tests/LiterateTests.fs
@@ -97,24 +97,10 @@ let test = 42"""
   let doc = Literate.ParseScriptString(content, "C" </> "comment.fsx", getFormatAgent())
   doc.Diagnostics |> Seq.length |> shouldEqual 0
   doc.Paragraphs |> Seq.length |> shouldEqual 3
-  doc.Paragraphs.[0..0] |> shouldMatchPar (function| YamlFrontmatter([_;_], _) -> true | _ -> false)
-  doc.Paragraphs.[1..1] |> shouldMatchPar (function| Heading _ -> true | _ -> false)
+  doc.Paragraphs.[0..0] |> shouldMatchPar (function YamlFrontmatter([_;_], _) -> true | _ -> false)
+  doc.Paragraphs.[1..1] |> shouldMatchPar (function Heading _ -> true | _ -> false)
   doc.Paragraphs.[2..2] |> shouldMatchPar (function MarkdownPatterns.LiterateParagraph(LiterateCode _) -> true | _ -> false)
 
-[<Test>]
-let ``Can parse literate F# script with incomplete frontmatter`` () =
-  let content = """
-(**
----
-key1: value1
-key2: value2
-*)
-let test = 42"""
-  let doc = Literate.ParseScriptString(content, "C" </> "comment.fsx", getFormatAgent())
-  doc.Diagnostics |> Seq.length |> shouldEqual 0
-  doc.Paragraphs |> Seq.length |> shouldEqual 2
-  doc.Paragraphs.[0..0] |> shouldMatchPar (function YamlFrontmatter([_;_], _) -> true | _ -> false)
-  doc.Paragraphs.[1..1] |> shouldMatchPar (function MarkdownPatterns.LiterateParagraph(LiterateCode _) -> true | _ -> false)
 
 [<Test>]
 let ``Can parse literate F# script with empty frontmatter`` () =


### PR DESCRIPTION
Implement #628  and use it within the docs for this repo

This adds frontmatter for title, category, categoryindex, index, e.g.

Literate scripts:
```
(**
---
title: Literate Script
category: Examples
categoryindex: 2
index: 1
---
*)
```
Markdown:
```
---
title: Literate Script
category: Examples
categoryindex: 2
index: 1
---
```

