### PR TITLE
Change error when no crackable projects are found to warning

### DIFF
--- a/src/FSharp.Formatting.CommandTool/ProjectCracker.fs
+++ b/src/FSharp.Formatting.CommandTool/ProjectCracker.fs
@@ -344,8 +344,7 @@ module Crack =
         //printfn "projectInfos = %A" projectInfos
 
         if projectInfos.Length = 0 && projectFiles.Length > 0 then
-            printfn "Error while cracking project files, no project files succeeded, exiting."
-            exit 1
+            printfn "Warning: While cracking project files, no project files succeeded."
 
         let param setting key v =
             match v with


### PR DESCRIPTION
This is a fix for issue #669 . If the command line tool is not supposed to fail when no crackable projects are found, even without `--noapidocs`, then changing the error to a warning (and removing the exit) should solve the problem. The build will still fail when the flag `--strict` is set.