### PR TITLE
Add --ignoreprojects flag

### DIFF
--- a/src/FSharp.Formatting.CommandTool/BuildCommand.fs
+++ b/src/FSharp.Formatting.CommandTool/BuildCommand.fs
@@ -339,6 +339,9 @@ type CoreBuildOptions(watch) =
     [<Option("noapidocs", Default= false, Required = false, HelpText = "Disable generation of API docs.")>]
     member val noapidocs = false with get, set
 
+    [<Option("ignoreprojects", Default= false, Required = false, HelpText = "Disable project cracking.")>]
+    member val ignoreprojects = false with get, set
+
     [<Option("strict", Default= false, Required = false, HelpText = "Fail if there is a problem generating docs.")>]
     member val strict = false with get, set
 
@@ -447,7 +450,7 @@ type CoreBuildOptions(watch) =
                            arr.[0], String.concat "=" arr.[1..]
                        else
                            failwith "properties must be of the form 'PropName=PropValue'")
-               Crack.crackProjects (this.strict, props, userRoot, userCollectionName, userParameters, projects), key1)
+               Crack.crackProjects (this.strict, props, userRoot, userCollectionName, userParameters, projects, this.ignoreprojects), key1)
 
         if crackedProjects.Length > 0 then
             printfn ""

--- a/src/FSharp.Formatting.CommandTool/ProjectCracker.fs
+++ b/src/FSharp.Formatting.CommandTool/ProjectCracker.fs
@@ -293,10 +293,9 @@ module Crack =
                 let collectionName = Path.GetFileName(slnDir)
                 collectionName, projectFiles
             | _, true ->
-                if userCollectionName.IsNone then
-                    printfn "Warning: Parameter `fsdocs-collection-name` not set, defaulting to `Project`"
-                let collectionName = defaultArg userCollectionName "Project"
+                let collectionName = defaultArg userCollectionName (Path.GetFileName slnDir)
                 collectionName, []
+
           //printfn "projects = %A" projectFiles
         let projectFiles =
             projectFiles |> List.choose (fun s ->


### PR DESCRIPTION
Reference to #669. Add the --ignoreprojects flag. When this flag is set, the list of project files is set to an empty list, which skips all the steps of project cracking.