### PR TITLE
Fix typo in location for fsdocs-custom.css

### DIFF
--- a/docs/styling.md
+++ b/docs/styling.md
@@ -71,7 +71,7 @@ As an example, here is [a page with `fsdocs-navbar-position` set to `fixed-right
 
 ## Customizing via CSS
 
-You can start styling by creating a file `docs/fsdocs-custom.css` and adding entries to it.  It is loaded by
+You can start styling by creating a file `docs/content/fsdocs-custom.css` and adding entries to it.  It is loaded by
 the standard template.  The CSS classes of generated content are:
 
 |  CSS class   | Corresponding Content|  


### PR DESCRIPTION
Line 74 said that `fsdocs-custom.css` should be in the `docs` folder, but this is incorrect. Line 31 was correct, it should be in `docs/content`.

This gif shows how moving a custom css file from `docs` to `docs/content` correctly changes the background from default (white) to a custom color (red).

![fsdocs-custom](https://user-images.githubusercontent.com/5226115/126361627-4519ea22-e758-4ba0-af40-34379d6f0ee9.gif)
