### PR TITLE
fix navbar scroll on desktop

### DIFF
--- a/docs/_template.html
+++ b/docs/_template.html
@@ -29,11 +29,11 @@
 </head>
 
 <body>
-    <nav class="navbar navbar-expand-md navbar-light bg-secondary navbar-nav-scroll {{fsdocs-navbar-position}}" id="fsdocs-nav">
+    <nav class="navbar navbar-expand-md navbar-light bg-secondary {{fsdocs-navbar-position}}" id="fsdocs-nav">
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
         </button>
-        <div class="collapse navbar-collapse" id="navbarsExampleDefault">
+        <div class="collapse navbar-collapse navbar-nav-scroll" id="navbarsExampleDefault">
             <a href="{{fsdocs-logo-link}}"><img id="fsdocs-logo" src="{{fsdocs-logo-src}}" /></a>
             <!-- BEGIN SEARCH BOX: this adds support for the search box -->
             <div id="header">

--- a/docs/sidebyside/_template.html
+++ b/docs/sidebyside/_template.html
@@ -32,7 +32,7 @@
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
         </button>
-        <div class="collapse navbar-collapse" id="navbarsExampleDefault">
+        <div class="collapse navbar-collapse navbar-nav-scroll" id="navbarsExampleDefault">
             <a href="{{fsdocs-logo-link}}"><img id="fsdocs-logo" src="{{fsdocs-logo-src}}" /></a>
             <!-- BEGIN SEARCH BOX: this adds support for the search box -->
             <div id="header">

--- a/docs/templates/leftside/_template.html
+++ b/docs/templates/leftside/_template.html
@@ -28,11 +28,11 @@
 </head>
 
 <body>
-    <nav class="navbar navbar-expand-md navbar-light bg-secondary navbar-nav-scroll fixed-right" id="fsdocs-nav">
+    <nav class="navbar navbar-expand-md navbar-light bg-secondary fixed-right" id="fsdocs-nav">
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
         </button>
-        <div class="collapse navbar-collapse" id="navbarsExampleDefault">
+        <div class="collapse navbar-collapse navbar-nav-scroll" id="navbarsExampleDefault">
             <a href="{{fsdocs-logo-link}}"><img id="fsdocs-logo" src="{{fsdocs-logo-src}}" /></a>
             <!-- BEGIN SEARCH BOX: this adds support for the search box -->
             <div id="header">


### PR DESCRIPTION
This fixes the desktop navbar scroll issue mentioned here https://github.com/fsprojects/FSharp.Formatting/issues/672#issuecomment-885012450

In the below gif, I first show the desktop experience with the navbar scroll only showing up when the browser window is shrunk vertically. Then I show the experience on mobile by shrinking horizontal space; if you click on the navbar button the scrollbar is visible.

![fixed-scroll](https://user-images.githubusercontent.com/5226115/126680267-34a0e11e-0054-4fd4-8011-b7ba375b58b9.gif)


