### PR TITLE
add blockquote style

### DIFF
--- a/docs/content/fsdocs-default.css
+++ b/docs/content/fsdocs-default.css
@@ -10,6 +10,17 @@ body {
 */
 }
 
+blockquote {
+    margin: 0 1em 0 0.25em;
+    margin-top: 0px;
+    margin-right: 1em;
+    margin-bottom: 0px;
+    margin-left: 0.25em;
+    padding: 0 .75em 0 1em;
+    border-left: 1px solid #777;
+    border-right: 0px solid #777;
+}
+
 /* Format the heading - nicer spacing etc. */
 .masthead {
     overflow: hidden;


### PR DESCRIPTION
Markdown defines blockquote using ">" but the current css does not style these elements. This pull request adds the blockquote style used by the markdown inventor Jon Gruber at his site [daringfireball.net](https://www.daringfireball.net).

Example script:
```fsharp
(**
This is some text.

> This is some text in a block quote.
>
> Another paragraph with the same text.
>    
> 1. Item 1
> 1. Item 2
>  
> ```fsharp
> let y = 4
> ```

A later paragraph
*)

let x = 4.4

(*** include-fsi-output ***)
```

### This is the result after the pull request:
![image](https://user-images.githubusercontent.com/5226115/129722735-a65240d5-dcb9-4d07-bffc-207bf7de528a.png)

### This is using the current css style:
![image](https://user-images.githubusercontent.com/5226115/129722824-9e7a27fd-b9f5-4153-86ff-81fad29197ad.png)

