### PR TITLE
Allow user-set ids for xmldoc example nodes

### DIFF
--- a/src/FSharp.Formatting.ApiDocs/GenerateHtml.fs
+++ b/src/FSharp.Formatting.ApiDocs/GenerateHtml.fs
@@ -215,7 +215,7 @@ type HtmlRender(model: ApiDocModel) =
 
                   for e in m.Comment.Examples do
                       h5 [Class "fsdocs-example-header"] [!! "Example"]
-                      p [Class "fsdocs-example"] [embed e]
+                      p [Class "fsdocs-example"; if e.Id.IsSome then Id e.Id.Value ] [embed e]
 
                   //if m.IsObsolete then
                   //    obsoleteMessage m.ObsoleteMessage

--- a/tests/FSharp.ApiDocs.Tests/ApiDocsTests.fs
+++ b/tests/FSharp.ApiDocs.Tests/ApiDocsTests.fs
@@ -617,6 +617,19 @@ let ``ApiDocs test FsLib1`` (format:OutputFormat) =
 
   files.ContainsKey (sprintf "fslib-test_omit.%s" format.Extension) |> shouldEqual false
 
+[<Test>]
+let ``ApiDocs test examples`` () =
+  let library = testBin </> "FsLib2.dll" |> fullpath
+
+  let files = generateApiDocs [library] OutputFormat.Html false "FsLib2_examples"
+
+  let testFile = sprintf "fslib-commentexamples.%s" OutputFormat.Html.Extension
+
+  files.ContainsKey testFile |> shouldEqual true
+  let content = files.[testFile]
+  content.Contains "has-id" |> shouldEqual true
+
+
 // -------------------Indirect links----------------------------------
 [<Test>]
 [<TestCaseSource("formats")>]

--- a/tests/FSharp.ApiDocs.Tests/files/FsLib2/Library2.fs
+++ b/tests/FSharp.ApiDocs.Tests/files/FsLib2/Library2.fs
@@ -127,4 +127,22 @@ module ``Space-Missing`` =
   /// Implicit cast operator test
   type ``Implicit-Cast``(value: int) = class end
   with static member op_Implicit (source: int) :  ``Implicit-Cast`` = ``Implicit-Cast``(source)
-    
+
+
+module CommentExamples =
+    /// <summary>this does the thing</summary>
+    /// <example>this is an example
+    /// </example>
+    let dothing() = ()
+
+    /// <summary>this does the thing</summary>
+    /// <example id="has-id">this is an example with an id
+    /// </example>
+    let dothing2() = ()
+
+    /// <summary>this does the thing</summary>
+    /// <example id="double-id">this is an example with an id
+    /// </example>
+    /// <example id="double-id">this is an example with an id
+    /// </example>
+    let doubleExampleId() = ()


### PR DESCRIPTION
Based on [this discussion](https://github.com/dotnet/fsharp/pull/12130#discussion_r704477523) it seems like we should support user-defined ids for examples (for example to allow deep-linking to a specific example).