### PR TITLE
Preserve underscores in emphasis.

### DIFF
--- a/src/FSharp.Formatting.Markdown/MarkdownParser.fs
+++ b/src/FSharp.Formatting.Markdown/MarkdownParser.fs
@@ -79,7 +79,21 @@ let (|DelimitedMarkdown|_|) bracket input =
     let rec loop acc =
         function
         | EscapedChar (x, xs) -> loop (x :: '\\' :: acc) xs
-        | input when List.startsWith endl input -> Some(List.rev acc, input)
+        | input when List.startsWith endl input ->
+            let rest = List.skip bracket.Length input
+
+            match rest with
+            | []
+            | (' '
+            | '\r'
+            | '\n'
+            | '.'
+            | '?'
+            | '!') :: _ -> Some(List.rev acc, input)
+            | rest ->
+                let head = List.take bracket.Length input
+                loop [ yield! head; yield! acc ] rest
+
         | x :: xs -> loop (x :: acc) xs
         | [] -> None
     // If it starts with 'startl', let's search for 'endl'
@@ -89,7 +103,6 @@ let (|DelimitedMarkdown|_|) bracket input =
         | None -> None
     else
         None
-
 
 /// This is similar to `List.Delimited`, but it skips over Latex inline math characters.
 let (|DelimitedLatexDisplayMath|_|) bracket input =

--- a/tests/FSharp.Markdown.Tests/Markdown.fs
+++ b/tests/FSharp.Markdown.Tests/Markdown.fs
@@ -790,3 +790,80 @@ let ``Parse blockquote with three leading spaces`` () =
           ) ]
 
     (Markdown.Parse doc).Paragraphs |> shouldEqual expected
+
+[<Test>]
+let ``Underscore inside italic is preserved`` () =
+    let doc = "_fsharp_space_after_comma_"
+
+    let expected =
+        [ Paragraph(
+              [ Emphasis(
+                    [ Literal(
+                          "fsharp_space_after_comma",
+                          Some(
+                              { StartLine = 1
+                                StartColumn = 0
+                                EndLine = 1
+                                EndColumn = 24 }
+                          )
+                      ) ],
+                    Some(
+                        { StartLine = 1
+                          StartColumn = 0
+                          EndLine = 1
+                          EndColumn = 26 }
+                    )
+                ) ],
+              Some(
+                  { StartLine = 1
+                    StartColumn = 0
+                    EndLine = 1
+                    EndColumn = 26 }
+              )
+          ) ]
+
+    (Markdown.Parse doc).Paragraphs |> shouldEqual expected
+
+[<Test>]
+let ``Underscores inside word in heading`` () =
+    let doc =
+        """
+### fsharp_bar_before_discriminated_union_declaration
+
+Always use a bar before every case in the declaration of a discriminated union.
+"""
+
+    let expected =
+        [ Heading(
+              3,
+              [ Literal(
+                    "fsharp_bar_before_discriminated_union_declaration",
+                    Some
+                        { StartLine = 2
+                          StartColumn = 4
+                          EndLine = 2
+                          EndColumn = 53 }
+                ) ],
+              Some
+                  { StartLine = 2
+                    StartColumn = 0
+                    EndLine = 2
+                    EndColumn = 53 }
+          )
+          Paragraph(
+              [ Literal(
+                    "Always use a bar before every case in the declaration of a discriminated union.",
+                    Some
+                        { StartLine = 4
+                          StartColumn = 0
+                          EndLine = 4
+                          EndColumn = 79 }
+                ) ],
+              Some
+                  { StartLine = 4
+                    StartColumn = 0
+                    EndLine = 4
+                    EndColumn = 79 }
+          ) ]
+
+    (Markdown.Parse doc).Paragraphs |> shouldEqual expected


### PR DESCRIPTION
Fixes #389.
This isn't an airtight fix but will work in the most common situations.
It worked for the Fantomas documentation.