### PR TITLE
Add HTML code element for code samples to enable syntax highlight.

### DIFF
--- a/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
+++ b/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
@@ -1938,12 +1938,20 @@ module internal SymbolReader =
 
                     html.Append("</code>") |> ignore
                 | "code" ->
+                    let lang =
+                        match elem.Attributes("lang") |> Seq.isEmpty with
+                        | true -> ""
+                        | false ->
+                            let lang = elem.Attribute("lang").Value
+                            $"{lang} language-{lang}"
                     html.Append("<pre>") |> ignore
+                    html.Append($"<code class=\"{lang}\">") |> ignore
 
                     let code = elem.Value.TrimEnd('\r', '\n', ' ')
                     let codeAsHtml = HttpUtility.HtmlEncode code
                     html.Append(codeAsHtml) |> ignore
 
+                    html.Append("</code>") |> ignore
                     html.Append("</pre>") |> ignore
                 // 'a' is not part of the XML doc standard but is widely used
                 | "a" -> html.Append(elem.ToString()) |> ignore


### PR DESCRIPTION
## Motivation
Enabling syntax highlights on XML documentation code samples will make it easy for readers and users of an API to understand the code samples quickly and without much effort. The current published version of `fsdocs` enable syntax highlight on comments written in markdown format. However, following the guidelines in [F# Recommended XML doc extensions for F# documentation tooling RFC](https://github.com/fsharp/fslang-design/blob/main/tooling/FST-1031-xmldoc-extensions.md) produces an output that has no syntax highlight nor we can add syntax highlight to it due to the HTML structure that the samples are written on, the structure is not the convention so, other libraries will not detect it.

Following the conventions from syntax highlighting libraries like [highlightjs](https://highlightjs.org/) and [prismjs](https://prismjs.com/) and [w3.org](https://www.w3.org/) site samples, the code samples should be put in a `code` element inside the `pre` element.

This PR attempt to add this to enable syntax lighlight.

Fixes #761

## Example

For example, for the following standard XML documentation code:

```F#
/// <summary>
/// A test module...
/// <example>
/// <code lang="fsharp">
///         let files =
///                [ "build"; "docs" ]
///                |> List.map (fun n -> sprintf "%s.zip" n)
/// </code>
/// </example>
/// </summary>
```

The result after using the tool to generate API documentation is as follows:

```diff
<pre>
+    <code class="fsharp language-fsharp">
        let files =
            [ "build"; "docs" ]
            |> List.map (fun n -> sprintf "%s.zip" n)
+    </code>
</pre>
```

Note that the language on XML `code` element has transferred and been mapped to the corresponding `HTML` element for syntax highlighters to get and operate on. In this way, users can pull a syntax highlighter and it will work out of the box.

By this, the XML documentation will be kept with no changes. However, the output HTML will be as follows with changes highlighted.


