### PR TITLE
Fix arguments naming and escape operator name in usageHtml

### DIFF
--- a/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
+++ b/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
@@ -1275,7 +1275,7 @@ module internal TypeFormatter =
         argName, argType
 
     // Format each argument, including its name and type
-    let formatArgUsageAsHtml _ctx i (arg: FSharpParameter) =
+    let formatArgUsageAsHtml i (arg: FSharpParameter) =
         let argName, _argType = formatArgNameAndType i arg
         !!argName
 
@@ -1465,11 +1465,11 @@ module internal SymbolReader =
                 | [ [ x; y ] ]
                 // binary operators (curried, like in FSharp.Core.Operators)
                 | [ [ x ]; [ y ] ] ->
-                    let left = formatArgUsageAsHtml () 0 x
+                    let left = formatArgUsageAsHtml 0 x
 
                     let nm = PrettyNaming.DecompileOpName v.CompiledName
 
-                    let right = formatArgUsageAsHtml () 1 y
+                    let right = formatArgUsageAsHtml 1 y
 
                     span [] [ left; !! "&#32;"; encode nm; !! "&#32;"; right ]
 

--- a/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
+++ b/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
@@ -1477,7 +1477,7 @@ module internal SymbolReader =
                 | [ [ x ] ] ->
                     let nm = PrettyNaming.DecompileOpName v.CompiledName
 
-                    let right = formatCurriedArgsUsageAsHtml true false [ [ x ] ]
+                    let right = formatArgUsageAsHtml 0 x
 
                     span [] [ encode nm; right ]
                 | _ ->

--- a/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
+++ b/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
@@ -1479,7 +1479,7 @@ module internal SymbolReader =
 
                     let right = formatCurriedArgsUsageAsHtml true false [ [ x ] ]
 
-                    span [] [ !!nm; right ]
+                    span [] [ encode nm; right ]
                 | _ ->
                     span
                         []

--- a/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
+++ b/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
@@ -1463,23 +1463,23 @@ module internal SymbolReader =
                 match argInfos with
                 // binary operators (taking a tuple)
                 | [ [ x; y ] ] ->
-                    let left = formatCurriedArgsUsageAsHtml true false [ [ x ] ]
+                    let left = formatArgUsageAsHtml () 1 x
 
                     let nm = PrettyNaming.DecompileOpName v.CompiledName
 
-                    let right = formatCurriedArgsUsageAsHtml true false [ [ y ] ]
+                    let right = formatArgUsageAsHtml () 2 y
 
-                    span [] [ left; !! "&#32;"; !!nm; !! "&#32;"; right ]
+                    span [] [ left; !! "&#32;"; !!HttpUtility.HtmlEncode(nm); !! "&#32;"; right ]
 
                 // binary operators (curried, like in FSharp.Core.Operators)
-                | [ args1; args2 ] ->
-                    let left = formatCurriedArgsUsageAsHtml true false [ args1 ]
+                | [ [ args1 ]; [ args2 ] ] ->
+                    let left = formatArgUsageAsHtml () 1 args1
 
                     let nm = PrettyNaming.DecompileOpName v.CompiledName
 
-                    let right = formatCurriedArgsUsageAsHtml true false [ args2 ]
+                    let right = formatArgUsageAsHtml () 2 args2
 
-                    span [] [ left; !! "&#32;"; !!nm; !! "&#32;"; right ]
+                    span [] [ left; !! "&#32;"; !!HttpUtility.HtmlEncode(nm); !! "&#32;"; right ]
 
                 // unary operators
                 | [ [ x ] ] ->

--- a/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
+++ b/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
@@ -1462,22 +1462,14 @@ module internal SymbolReader =
             | _, false, _, name, _ when PrettyNaming.IsMangledOpName v.CompiledName ->
                 match argInfos with
                 // binary operators (taking a tuple)
-                | [ [ x; y ] ] ->
-                    let left = formatArgUsageAsHtml () 1 x
-
-                    let nm = PrettyNaming.DecompileOpName v.CompiledName
-
-                    let right = formatArgUsageAsHtml () 2 y
-
-                    span [] [ left; !! "&#32;"; !!HttpUtility.HtmlEncode(nm); !! "&#32;"; right ]
-
+                | [ [ x; y ] ]
                 // binary operators (curried, like in FSharp.Core.Operators)
-                | [ [ args1 ]; [ args2 ] ] ->
-                    let left = formatArgUsageAsHtml () 1 args1
+                | [ [ x ]; [ y ] ] ->
+                    let left = formatArgUsageAsHtml () 0 x
 
                     let nm = PrettyNaming.DecompileOpName v.CompiledName
 
-                    let right = formatArgUsageAsHtml () 2 args2
+                    let right = formatArgUsageAsHtml () 1 y
 
                     span [] [ left; !! "&#32;"; !!HttpUtility.HtmlEncode(nm); !! "&#32;"; right ]
 

--- a/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
+++ b/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
@@ -1471,7 +1471,7 @@ module internal SymbolReader =
 
                     let right = formatArgUsageAsHtml () 1 y
 
-                    span [] [ left; !! "&#32;"; !!HttpUtility.HtmlEncode(nm); !! "&#32;"; right ]
+                    span [] [ left; !! "&#32;"; encode nm; !! "&#32;"; right ]
 
                 // unary operators
                 | [ [ x ] ] ->

--- a/tests/FSharp.ApiDocs.Tests/ApiDocsTests.fs
+++ b/tests/FSharp.ApiDocs.Tests/ApiDocsTests.fs
@@ -263,13 +263,13 @@ let ``ApiDocs works on two sample F# assemblies`` (format: OutputFormat) =
     files[$"fslib-operatorswithfsi.%s{format.Extension}"]
     |> shouldContainText "x&#32;?&lt;?&#32;y"
 
-    // -arg0
+    // <?arg0
     files[$"fslib-operatorswithfsi.%s{format.Extension}"]
-    |> shouldContainText "~-arg0"
+    |> shouldContainText "&lt;?arg0"
 
-    // ?-x
+    // <?>x
     files[$"fslib-operatorswithfsi.%s{format.Extension}"]
-    |> shouldContainText "~?-x"
+    |> shouldContainText "&lt;?&gt;x"
 
     (* This may be addressed in a separate issue or removed if not an issue.
   // Check that implict cast operator is generated correctly

--- a/tests/FSharp.ApiDocs.Tests/ApiDocsTests.fs
+++ b/tests/FSharp.ApiDocs.Tests/ApiDocsTests.fs
@@ -253,6 +253,17 @@ let ``ApiDocs works on two sample F# assemblies`` (format: OutputFormat) =
     files.[(sprintf "fslib-union.%s" format.Extension)]
     |> shouldContainText "<span>Naming(<span>rate,&#32;string</span>)</span>"
 
+    // Check that operators are encoded
+    files[$"fslib-operatorswithfsi.%s{format.Extension}"]
+    |> shouldContainText "&lt;&amp;&gt;"
+
+    // Check that parameters are indexed
+    files[$"fslib-operatorswithfsi.%s{format.Extension}"]
+    |> shouldContainText "arg0"
+
+    files[$"fslib-operatorswithfsi.%s{format.Extension}"]
+    |> shouldContainText "arg1"
+
     (* This may be addressed in a separate issue or removed if not an issue.
   // Check that implict cast operator is generated correctly
   files.[(sprintf "fslib-space-missing-implicit-cast.%s" format.Extension)] |> shouldContainText "<code><span>op_Implicit&#32;<span>source</span></span></code>"

--- a/tests/FSharp.ApiDocs.Tests/ApiDocsTests.fs
+++ b/tests/FSharp.ApiDocs.Tests/ApiDocsTests.fs
@@ -254,15 +254,22 @@ let ``ApiDocs works on two sample F# assemblies`` (format: OutputFormat) =
     |> shouldContainText "<span>Naming(<span>rate,&#32;string</span>)</span>"
 
     // Check that operators are encoded
-    files[$"fslib-operatorswithfsi.%s{format.Extension}"]
-    |> shouldContainText "&lt;&amp;&gt;"
 
-    // Check that parameters are indexed
+    // arg0 <&> arg1
     files[$"fslib-operatorswithfsi.%s{format.Extension}"]
-    |> shouldContainText "arg0"
+    |> shouldContainText "arg0&#32;&lt;&amp;&gt;&#32;arg1"
 
+    // x ?<? y
     files[$"fslib-operatorswithfsi.%s{format.Extension}"]
-    |> shouldContainText "arg1"
+    |> shouldContainText "x&#32;?&lt;?&#32;y"
+
+    // -arg0
+    files[$"fslib-operatorswithfsi.%s{format.Extension}"]
+    |> shouldContainText "~-arg0"
+
+    // ?-x
+    files[$"fslib-operatorswithfsi.%s{format.Extension}"]
+    |> shouldContainText "~?-x"
 
     (* This may be addressed in a separate issue or removed if not an issue.
   // Check that implict cast operator is generated correctly

--- a/tests/FSharp.ApiDocs.Tests/files/FsLib1/FsLib1.fsproj
+++ b/tests/FSharp.ApiDocs.Tests/files/FsLib1/FsLib1.fsproj
@@ -6,6 +6,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Library1.fs" />
+    <Compile Include="OperatorsWithFsi.fsi" />
+    <Compile Include="OperatorsWithFsi.fs" />
     <None Include="paket.references" />
   </ItemGroup>
   <Import Project="..\..\..\..\.paket\Paket.Restore.targets" />

--- a/tests/FSharp.ApiDocs.Tests/files/FsLib1/OperatorsWithFsi.fs
+++ b/tests/FSharp.ApiDocs.Tests/files/FsLib1/OperatorsWithFsi.fs
@@ -1,6 +1,6 @@
 ﻿module FsLib.OperatorsWithFsi
 
-let ( <&> ) x y = x > y
-let ( ?<? ) x y = x > y
+let (<&>) x y = x > y
+let (?<?) x y = x > y
 let (<?) x = x
 let (<?>) x = x

--- a/tests/FSharp.ApiDocs.Tests/files/FsLib1/OperatorsWithFsi.fs
+++ b/tests/FSharp.ApiDocs.Tests/files/FsLib1/OperatorsWithFsi.fs
@@ -1,4 +1,6 @@
 ﻿module FsLib.OperatorsWithFsi
 
-let (<&>) (x: 'T) (y: 'T) = x < y
-
+let ( <&> ) x y = x > y
+let ( ?<? ) x y = x > y
+let (~-) x = x
+let (~?-) x = x

--- a/tests/FSharp.ApiDocs.Tests/files/FsLib1/OperatorsWithFsi.fs
+++ b/tests/FSharp.ApiDocs.Tests/files/FsLib1/OperatorsWithFsi.fs
@@ -2,5 +2,5 @@
 
 let ( <&> ) x y = x > y
 let ( ?<? ) x y = x > y
-let (~-) x = x
-let (~?-) x = x
+let (<?) x = x
+let (<?>) x = x

--- a/tests/FSharp.ApiDocs.Tests/files/FsLib1/OperatorsWithFsi.fs
+++ b/tests/FSharp.ApiDocs.Tests/files/FsLib1/OperatorsWithFsi.fs
@@ -1,0 +1,4 @@
+﻿module FsLib.OperatorsWithFsi
+
+let (<&>) (x: 'T) (y: 'T) = x < y
+

--- a/tests/FSharp.ApiDocs.Tests/files/FsLib1/OperatorsWithFsi.fsi
+++ b/tests/FSharp.ApiDocs.Tests/files/FsLib1/OperatorsWithFsi.fsi
@@ -1,14 +1,13 @@
 ﻿module FsLib.OperatorsWithFsi
 
 /// <summary>The binary operator 1</summary>
-val ( <&> ): 'T -> 'T -> bool when 'T : comparison
+val (<&>): 'T -> 'T -> bool when 'T: comparison
 
 /// <summary>The binary operator 2</summary>
-val ( ?<? ): x: 'T -> y: 'T -> bool when 'T : comparison
+val (?<?): x: 'T -> y: 'T -> bool when 'T: comparison
 
 /// <summary>The unary operator 1</summary>
 val (<?): 'T -> 'T
 
 /// <summary>The unary operator 2</summary>
 val (<?>): x: 'T -> 'T
-

--- a/tests/FSharp.ApiDocs.Tests/files/FsLib1/OperatorsWithFsi.fsi
+++ b/tests/FSharp.ApiDocs.Tests/files/FsLib1/OperatorsWithFsi.fsi
@@ -1,0 +1,5 @@
+﻿module FsLib.OperatorsWithFsi
+
+/// <summary>The operator</summary>
+val ( <&> ) : 'T -> 'T -> bool when 'T : comparison
+

--- a/tests/FSharp.ApiDocs.Tests/files/FsLib1/OperatorsWithFsi.fsi
+++ b/tests/FSharp.ApiDocs.Tests/files/FsLib1/OperatorsWithFsi.fsi
@@ -7,8 +7,8 @@ val ( <&> ): 'T -> 'T -> bool when 'T : comparison
 val ( ?<? ): x: 'T -> y: 'T -> bool when 'T : comparison
 
 /// <summary>The unary operator 1</summary>
-val (~-): 'T -> 'T
+val (<?): 'T -> 'T
 
 /// <summary>The unary operator 2</summary>
-val (~?-): x: 'T -> 'T
+val (<?>): x: 'T -> 'T
 

--- a/tests/FSharp.ApiDocs.Tests/files/FsLib1/OperatorsWithFsi.fsi
+++ b/tests/FSharp.ApiDocs.Tests/files/FsLib1/OperatorsWithFsi.fsi
@@ -1,5 +1,14 @@
 ﻿module FsLib.OperatorsWithFsi
 
-/// <summary>The operator</summary>
-val ( <&> ) : 'T -> 'T -> bool when 'T : comparison
+/// <summary>The binary operator 1</summary>
+val ( <&> ): 'T -> 'T -> bool when 'T : comparison
+
+/// <summary>The binary operator 2</summary>
+val ( ?<? ): x: 'T -> y: 'T -> bool when 'T : comparison
+
+/// <summary>The unary operator 1</summary>
+val (~-): 'T -> 'T
+
+/// <summary>The unary operator 2</summary>
+val (~?-): x: 'T -> 'T
 


### PR DESCRIPTION
Some operator names are displayed incorrectly due to missing escaping; also, the argument names are duplicated.
This PR fixes that.

Before:
https://github.com/dotnet/fsharp/blob/0063f20f6cd49d016d5d234b9c1b7df00c2e9a4d/src/FSharp.Core/Nullable.fsi#L173
![image](https://user-images.githubusercontent.com/26364714/187056162-88763d5a-086e-4912-b1c0-d1eda8cb5b43.png)
![image](https://user-images.githubusercontent.com/26364714/187056243-fe65b694-97ef-4292-8611-871e50492d2c.png)


After:
![image](https://user-images.githubusercontent.com/26364714/187056176-2f9220c7-f208-43a3-9ff2-508f651b60a7.png)


- [x] Tests

cc @BoundedChenn31