### PR TITLE
Prefix `{{root}}` to favicon path

### DIFF
--- a/docs/_template.html
+++ b/docs/_template.html
@@ -13,7 +13,7 @@
 
     <script type="text/javascript" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-MML-AM_CHTML"></script>
 
-    <link rel="shortcut icon" type="image/x-icon" href="img/favicon.ico">
+    <link rel="shortcut icon" type="image/x-icon" href="{{root}}img/favicon.ico">
     <link type="text/css" rel="stylesheet" href="{{root}}content/navbar-{{fsdocs-navbar-position}}.css" />
     <link type="text/css" rel="stylesheet" href="{{root}}content/fsdocs-{{fsdocs-theme}}.css" />
     <link type="text/css" rel="stylesheet" href="{{root}}content/fsdocs-custom.css" />

--- a/tests/FSharp.ApiDocs.Tests/ApiDocsTests.fs
+++ b/tests/FSharp.ApiDocs.Tests/ApiDocsTests.fs
@@ -1080,6 +1080,11 @@ let ``ApiDocs test examples`` () =
     let content = files.[testFile]
     content.Contains "has-id" |> shouldEqual true
 
+    // Check that the favicon href points to the root.
+    let testFile = $"fslib.{OutputFormat.Html.Extension}"
+    files.ContainsKey testFile |> shouldEqual true
+    let content = files[testFile]
+    content.Contains "href=\"/root/img/favicon.ico\"" |> shouldEqual true
 
 // -------------------Indirect links----------------------------------
 [<Test>]


### PR DESCRIPTION
Resolves #773.

The test is not the most sophisticated... but it does fail before the change and pass after.

Let me know if I should update the release notes, etc.