### PR TITLE
Add node_modules directory to ignored list of files and directories.

### DIFF
--- a/docs/content.fsx
+++ b/docs/content.fsx
@@ -66,7 +66,7 @@ copy of this content in your `content` directory.
 
 ## Ignored Content
 
-Any file or directory beginning with `.` is ignored.
+Any file or directory beginning with `.` is ignored. Also `node_modules` directory is ignored.
 
 ## Front matter
 

--- a/src/fsdocs-tool/BuildCommand.fs
+++ b/src/fsdocs-tool/BuildCommand.fs
@@ -94,6 +94,10 @@ type internal DocContent
         |> Array.filter (fun x -> x.Length = 2)
         |> Array.distinct
 
+    let sourceFileOrFolderIsSkipped (input: string) =
+        input.StartsWith "." ||
+        input = "node_modules"
+
     let makeMarkdownLinkResolver
         (inputFolderAsGiven, outputFolderRelativeToRoot, fullPathFileMap: Map<(string * OutputKind), string>, outputKind)
         (markdownReference: string)
@@ -155,7 +159,7 @@ type internal DocContent
 
           for subInputFolderFullPath in Directory.EnumerateDirectories(inputFolderAsGiven) do
               let subInputFolderName = Path.GetFileName(subInputFolderFullPath)
-              let subFolderIsSkipped = subInputFolderName.StartsWith "."
+              let subFolderIsSkipped = sourceFileOrFolderIsSkipped subInputFolderName
               let subFolderIsOutput = subFolderIsOutput subInputFolderFullPath
 
               if not subFolderIsOutput && not subFolderIsSkipped then
@@ -485,7 +489,7 @@ type internal DocContent
 
           for subInputFolderFullPath in Directory.EnumerateDirectories(inputFolderAsGiven) do
               let subInputFolderName = Path.GetFileName(subInputFolderFullPath)
-              let subFolderIsSkipped = subInputFolderName.StartsWith "."
+              let subFolderIsSkipped = sourceFileOrFolderIsSkipped subInputFolderName
               let subFolderIsOutput = subFolderIsOutput subInputFolderFullPath
 
               if subFolderIsOutput || subFolderIsSkipped then


### PR DESCRIPTION
## Motivation
In a recent project I was working on, I customized the theme that FSDocs operate on. The customized theme was first processed with NPM, then template files were fed to FSDocs to use. So as a general highlight of the pipeline:
1. run `npm install` to install node dependencies,
2. run `npm run build` to generate the final build output from NPM, this includes final template HTML files as well as styling and JavaScript files,
3. run `dotnet fsdocs` to generate the site and API documentation.

One issue that results from this flow is that we have `node_modules` directory that resulted from `npm install` and is needed in `npm run build`. That directory got processed by FSDocs when it runs. Hence we get in output a `node_modules` directory with thousands of files! In addition, the run time for FSDocs has doubled.

The workaround I did was to rename the `node_modules` directory to `.node_modules` before running step number 3 above. Since FSDocs ignore files and directories that start with a dot. Once FSDocs is done, I rename it back to `node_modules`.

The issue with this approach is that, during development, we need to run FSDocs and NPM both in watch modes, but we cannot, since `node_modules` directory has been renamed, hence NPM cannot be run. So we run either of them.

## The Change

This PR adds an ignore list-like function that has the `node_modules` directory and "." criteria. In which it will ignore either of them. Also, I updated the documentation page to highlight this in the Ignored Content section.
