### PR TITLE
Use fssnip highlighter in API docs code examples.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+## 17.1.0
+* [Add syntax highlighting to API docs](https://github.com/fsprojects/FSharp.Formatting/pull/780)
+
 ## 17.0.0
 
 * Update to .NET 7.0.100

--- a/build/build.fs
+++ b/build/build.fs
@@ -103,9 +103,9 @@ let generateDocs _ =
         ("install --no-cache --version "
          + release.NugetVersion
          + " --add-source "
-         + artifactsDir
+         + "\"" + artifactsDir + "\"" 
          + " --tool-path "
-         + artifactsDir
+         + "\"" + artifactsDir + "\""
          + " fsdocs-tool")
     |> ignore
 

--- a/build/build.fs
+++ b/build/build.fs
@@ -103,9 +103,13 @@ let generateDocs _ =
         ("install --no-cache --version "
          + release.NugetVersion
          + " --add-source "
-         + "\"" + artifactsDir + "\"" 
+         + "\""
+         + artifactsDir
+         + "\""
          + " --tool-path "
-         + "\"" + artifactsDir + "\""
+         + "\""
+         + artifactsDir
+         + "\""
          + " fsdocs-tool")
     |> ignore
 

--- a/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
+++ b/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
@@ -1877,22 +1877,10 @@ module internal SymbolReader =
 
                     html.Append("</code>") |> ignore
                 | "code" ->
-                    let lang =
-                        match elem.Attributes("lang") |> Seq.isEmpty with
-                        | true -> ""
-                        | false ->
-                            let lang = elem.Attribute("lang").Value
-                            $"{lang} language-{lang}"
-
-                    html.Append("<pre>") |> ignore
-                    html.Append($"<code class=\"{lang}\">") |> ignore
-
-                    let code = elem.Value.TrimEnd('\r', '\n', ' ')
-                    let codeAsHtml = HttpUtility.HtmlEncode code
-                    html.Append(codeAsHtml) |> ignore
-
-                    html.Append("</code>") |> ignore
-                    html.Append("</pre>") |> ignore
+                    let code = 
+                        let code = Literate.ParseMarkdownString ("```\n" + elem.Value + "\n```")
+                        Literate.ToHtml(code, lineNumbers = false)
+                    html.Append(code) |> ignore
                 // 'a' is not part of the XML doc standard but is widely used
                 | "a" -> html.Append(elem.ToString()) |> ignore
                 // This allows any HTML to be transferred through

--- a/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
+++ b/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
@@ -1878,7 +1878,7 @@ module internal SymbolReader =
                     html.Append("</code>") |> ignore
                 | "code" ->
                     let code =
-                        let code = Literate.ParseMarkdownString("```\n" + elem.Value + "\n```")
+                        let code = Literate.ParseMarkdownString("```\n" + elem.Value.TrimEnd('\r', '\n', ' ') + "\n```")
                         Literate.ToHtml(code, lineNumbers = false)
 
                     html.Append(code) |> ignore

--- a/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
+++ b/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
@@ -1877,9 +1877,10 @@ module internal SymbolReader =
 
                     html.Append("</code>") |> ignore
                 | "code" ->
-                    let code = 
-                        let code = Literate.ParseMarkdownString ("```\n" + elem.Value + "\n```")
+                    let code =
+                        let code = Literate.ParseMarkdownString("```\n" + elem.Value + "\n```")
                         Literate.ToHtml(code, lineNumbers = false)
+
                     html.Append(code) |> ignore
                 // 'a' is not part of the XML doc standard but is widely used
                 | "a" -> html.Append(elem.ToString()) |> ignore


### PR DESCRIPTION
This adds syntax highlighting to API docs code examples. PR #762 from @yazeedobaid was solving the same problem, but it relied on external tools such as highlight.js to do the highlighting and required users to add that dependency. This PR uses FSharp.Formatting's baked-in highlighter to achieve the same goal.

For example, building the F# core docs [Array.averageBy](https://fsharp.github.io/fsharp-core-docs/reference/fsharp-collections-arraymodule.html#averageBy) example using this PR:

![image](https://user-images.githubusercontent.com/5226115/202795199-d2396454-3675-4e18-8271-980372ed81c7.png)

----------------------

In comparison, this is how it looks now:

![image](https://user-images.githubusercontent.com/5226115/202795255-70799793-a775-4ea2-ad1a-5efe838cbac4.png)
