### PR TITLE
fix apidocs markdown comment

### DIFF
--- a/docs/apidocs.fsx
+++ b/docs/apidocs.fsx
@@ -169,7 +169,7 @@ type GenericClass2<'T>() =
 /// and <see cref="M:TheNamespace.GenericClass2`1.GenericMethod``1(`0,``0)" />
 let referringFunction2 () = "result"
 
-(*
+(**
 
 ## Go to Source links
 


### PR DESCRIPTION
Typo, was "(*" instead of "(**". As a result the *Go to Source links* and *Markdown Comments* section of the api docs was rendering as a regular code comment.

This typo was created in PR #600. Prior to that PR it started with "(**".

This only affects the docs, no new release of the tool is needed.