### PR TITLE
chore: Update MS external links from docs subdomain to learn subdomain

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -111,7 +111,7 @@
     <MSBuild Projects="$(PaketToolsPath)paket.bootstrapper.proj" Targets="Restore" />
   </Target>
 
-  <!-- Official workaround for https://docs.microsoft.com/en-us/visualstudio/msbuild/getfilehash-task?view=vs-2019 -->
+  <!-- Official workaround for https://learn.microsoft.com/en-us/visualstudio/msbuild/getfilehash-task?view=vs-2019 -->
   <UsingTask TaskName="Microsoft.Build.Tasks.GetFileHash" AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition=" '$(MSBuildSupportsHashing)' == 'true' And '$(DetectedMSBuildVersion)' &lt; '16.0.360' " />
   <UsingTask TaskName="Microsoft.Build.Tasks.VerifyFileHash" AssemblyName="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition=" '$(MSBuildSupportsHashing)' == 'true' And '$(DetectedMSBuildVersion)' &lt; '16.0.360' " />
   <Target Name="PaketRestore" Condition="'$(PaketRestoreDisabled)' != 'True'" BeforeTargets="_GenerateDotnetCliToolReferenceSpecs;_GenerateProjectRestoreGraphPerFramework;_GenerateRestoreGraphWalkPerFramework;CollectPackageReferences" DependsOnTargets="SetPaketCommand;PaketBootstrapping">

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+## 17.2.3
+
+* Fix external docs link [#794](https://github.com/fsprojects/FSharp.Formatting/issues/794)
+
 ## 17.2.2
 
 * Improvement for `<seealso/>` [#789](https://github.com/fsprojects/FSharp.Formatting/issues/789)

--- a/docs/apidocs.fsx
+++ b/docs/apidocs.fsx
@@ -64,7 +64,7 @@ Usually the same template can be used as for [other content](content.html).
 
 ## Classic XML Doc Comments
 
-XML Doc Comments may use [the normal F# and C# XML doc standards](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/xmldoc/).
+XML Doc Comments may use [the normal F# and C# XML doc standards](https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/xmldoc/).
 
 The tags that form the core of the XML doc specification are:
 

--- a/docs/content/fsdocs-default.css
+++ b/docs/content/fsdocs-default.css
@@ -103,7 +103,7 @@ blockquote {
 
 
 /*--------------------------------------------------------------------------
-  Formatting tables in fsdocs-content, using docs.microsoft.com tables
+  Formatting tables in fsdocs-content, using learn.microsoft.com tables
 /*--------------------------------------------------------------------------*/
 
 #fsdocs-content .table {

--- a/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
+++ b/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
@@ -947,7 +947,7 @@ type internal CrossReferenceResolver(root, collectionName, qualify, extensions) 
 
             let docs = noParen.Replace("``", "").Replace("`", "-").ToLower()
 
-            let link = sprintf "https://docs.microsoft.com/dotnet/api/%s" docs
+            let link = sprintf "https://learn.microsoft.com/dotnet/api/%s" docs
 
             { IsInternal = false
               ReferenceLink = link

--- a/tests/FSharp.ApiDocs.Tests/ApiDocsTests.fs
+++ b/tests/FSharp.ApiDocs.Tests/ApiDocsTests.fs
@@ -644,7 +644,7 @@ let ``ApiDocs test that cref generation works`` (format: OutputFormat) =
     |> shouldContainText "Assembly"
 
     files.[(sprintf "creflib4-class4.%s" format.Extension)]
-    |> shouldContainText "https://docs.microsoft.com/dotnet/api/system.reflection.assembly"
+    |> shouldContainText "https://learn.microsoft.com/dotnet/api/system.reflection.assembly"
 
     // F# tests (at least we not not crash for them, compiler doesn't resolve anything)
     // reference class in same assembly
@@ -660,7 +660,7 @@ let ``ApiDocs test that cref generation works`` (format: OutputFormat) =
 
     files.[(sprintf "creflib2-class4.%s" format.Extension)]
     |> shouldContainText "Assembly"
-    //files.[(sprintf "creflib2-class4.%s" format.Extension)] |> shouldContainText "https://docs.microsoft.com/dotnet/api/system.reflection.assembly"
+    //files.[(sprintf "creflib2-class4.%s" format.Extension)] |> shouldContainText "https://learn.microsoft.com/dotnet/api/system.reflection.assembly"
 
     // F# tests (fully quallified)
     // reference class in same assembly
@@ -689,7 +689,7 @@ let ``ApiDocs test that cref generation works`` (format: OutputFormat) =
     |> shouldContainText "Assembly"
 
     files.[(sprintf "creflib2-class8.%s" format.Extension)]
-    |> shouldContainText "https://docs.microsoft.com/dotnet/api/system.reflection.assembly"
+    |> shouldContainText "https://learn.microsoft.com/dotnet/api/system.reflection.assembly"
 
 [<Test>]
 [<TestCaseSource("formats")>]


### PR DESCRIPTION
~Marking this as a draft while I try to build this project with fsharp-core-docs as requested [here](https://github.com/fsprojects/FSharp.Formatting/issues/794#issuecomment-1435754573).~ Based on the conversation in the linked issue, I might not be able to debug this on Linux. I'm opening up the PR. C'est la vie. 

related https://github.com/fsprojects/FSharp.Formatting/issues/794