### PR TITLE
`docs` → `learn`

### DIFF
--- a/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
+++ b/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
@@ -947,7 +947,7 @@ type internal CrossReferenceResolver(root, collectionName, qualify, extensions) 
 
             let docs = noParen.Replace("``", "").Replace("`", "-").ToLower()
 
-            let link = sprintf "https://docs.microsoft.com/dotnet/api/%s" docs
+            let link = sprintf "https://learn.microsoft.com/dotnet/api/%s" docs
 
             { IsInternal = false
               ReferenceLink = link

--- a/tests/FSharp.ApiDocs.Tests/ApiDocsTests.fs
+++ b/tests/FSharp.ApiDocs.Tests/ApiDocsTests.fs
@@ -644,7 +644,7 @@ let ``ApiDocs test that cref generation works`` (format: OutputFormat) =
     |> shouldContainText "Assembly"
 
     files.[(sprintf "creflib4-class4.%s" format.Extension)]
-    |> shouldContainText "https://docs.microsoft.com/dotnet/api/system.reflection.assembly"
+    |> shouldContainText "https://learn.microsoft.com/dotnet/api/system.reflection.assembly"
 
     // F# tests (at least we not not crash for them, compiler doesn't resolve anything)
     // reference class in same assembly
@@ -660,7 +660,7 @@ let ``ApiDocs test that cref generation works`` (format: OutputFormat) =
 
     files.[(sprintf "creflib2-class4.%s" format.Extension)]
     |> shouldContainText "Assembly"
-    //files.[(sprintf "creflib2-class4.%s" format.Extension)] |> shouldContainText "https://docs.microsoft.com/dotnet/api/system.reflection.assembly"
+    //files.[(sprintf "creflib2-class4.%s" format.Extension)] |> shouldContainText "https://learn.microsoft.com/dotnet/api/system.reflection.assembly"
 
     // F# tests (fully quallified)
     // reference class in same assembly
@@ -689,7 +689,7 @@ let ``ApiDocs test that cref generation works`` (format: OutputFormat) =
     |> shouldContainText "Assembly"
 
     files.[(sprintf "creflib2-class8.%s" format.Extension)]
-    |> shouldContainText "https://docs.microsoft.com/dotnet/api/system.reflection.assembly"
+    |> shouldContainText "https://learn.microsoft.com/dotnet/api/system.reflection.assembly"
 
 [<Test>]
 [<TestCaseSource("formats")>]


### PR DESCRIPTION
`docs.microsoft.com` was rebranded last year to `learn.microsoft.com` (as announced [here](https://techcommunity.microsoft.com/t5/microsoft-learn-blog/build-skills-that-open-doors-with-microsoft-learn/ba-p/3614011)). Even though existing `docs.microsoft.com` links are redirected to `learn.microsoft.com`, it seems like we might as well generate canonical links.

Compare dotnet/aspnetcore#44175, dotnet/aspnetcore#46206.

(I didn't update existing references to `docs.microsoft.com` in comments, etc., in this repo, but I can if we want.)