### PR TITLE
Test projects

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+## 17.3.0
+
+* Better test project detection [#800](https://github.com/fsprojects/FSharp.Formatting/issues/800)
+
 ## 17.2.3
 
 * Fix external docs link [#794](https://github.com/fsprojects/FSharp.Formatting/issues/794)

--- a/src/fsdocs-tool/ProjectCracker.fs
+++ b/src/fsdocs-tool/ProjectCracker.fs
@@ -426,12 +426,12 @@ module Crack =
         let projectFiles =
             projectFiles
             |> List.choose (fun s ->
-                if s.Contains(".Tests") || s.Contains("test") then
-                    printfn "  skipping project '%s' because it looks like a test project" (Path.GetFileName s)
+                if s.Contains("FSharp.ApiDocs.Tests") || s.Contains("FSharp.Formatting.TestHelpers") then
+                    printfn "  skipping project '%s' because it looks like a FSharp.Formatting test project" (Path.GetFileName s)
                     None
                 else
                     Some s)
-
+        
         //printfn "filtered projects = %A" projectFiles
         if projectFiles.Length = 0 && (ignoreProjects |> not) then
             printfn "no project files found, no API docs will be generated"

--- a/src/fsdocs-tool/ProjectCracker.fs
+++ b/src/fsdocs-tool/ProjectCracker.fs
@@ -425,15 +425,16 @@ module Crack =
         //printfn "projects = %A" projectFiles
         let projectFiles =
             projectFiles
-            |> List.choose (fun s ->
-                // Other libraries' test projects will be filtered out by projInfos later on,
-                // but this make sure FSharp.Formatting.ApiDocs test projects get excluded.
-                if s.Contains("tests\\FSharp") then
-                    printfn "  skipping project '%s' because it looks like a test project" (Path.GetFileName s)
+            |> List.filter (fun s ->
+                let isFSharpFormattingTestProject =
+                    s.Contains $"FSharp.ApiDocs.Tests{Path.DirectorySeparatorChar}files"
+                    || s.EndsWith "FSharp.Formatting.TestHelpers.fsproj"
 
-                    None
-                else
-                    Some s)
+                if isFSharpFormattingTestProject then
+                    printfn
+                        $"  skipping project '%s{Path.GetFileName s}' because the project is part of the FSharp.Formatting test suite."
+
+                not isFSharpFormattingTestProject)
 
         //printfn "filtered projects = %A" projectFiles
         if projectFiles.Length = 0 && (ignoreProjects |> not) then

--- a/src/fsdocs-tool/ProjectCracker.fs
+++ b/src/fsdocs-tool/ProjectCracker.fs
@@ -426,12 +426,15 @@ module Crack =
         let projectFiles =
             projectFiles
             |> List.choose (fun s ->
-                if s.Contains("FSharp.ApiDocs.Tests") || s.Contains("FSharp.Formatting.TestHelpers") then
-                    printfn "  skipping project '%s' because it looks like a FSharp.Formatting test project" (Path.GetFileName s)
+                // Other libraries' test projects will be filtered out by projInfos later on,
+                // but this make sure FSharp.Formatting.ApiDocs test projects get excluded.
+                if s.Contains("tests\\FSharp") then
+                    printfn "  skipping project '%s' because it looks like a test project" (Path.GetFileName s)
+
                     None
                 else
                     Some s)
-        
+
         //printfn "filtered projects = %A" projectFiles
         if projectFiles.Length = 0 && (ignoreProjects |> not) then
             printfn "no project files found, no API docs will be generated"


### PR DESCRIPTION
Fixes #800. Mostly relies on projInfos now to exclude test projects, but for building FSharp.Formatting docs correctly we need custom code to exclude this library's own test projects from the ApiDocs.

I exclude FSharp.Formatting test projects using
```fsharp
if s.Contains("tests\\FSharp") then
```

We could be more explicit, such as below, but then if a future person adds additional test projects to this library they might forget to explicitly exclude them

```fsharp
if s.Contains("FSharp.ApiDocs.Tests") || s.Contains("FSharp.Formatting.TestHelpers")
```

