### PR TITLE
Always use lf for F# files.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -20,3 +20,8 @@
 *.PDF	 diff=astextplain
 *.rtf	 diff=astextplain
 *.RTF	 diff=astextplain
+
+# Always use lf for F# files
+*.fs text eol=lf
+*.fsx text eol=lf
+*.fsi text eol=lf


### PR DESCRIPTION
Because our `.editorconfig` specifies

https://github.com/fsprojects/FSharp.Formatting/blob/e665aa95ab897e5e2c543e5847f3820b3e215e92/.editorconfig#L5

Life is gets easier if all F# files are just checkout-out as `lf` by everyone.
Right now, when I run `dotnet fantomas src -r`, all files are touched.
The reason for this is that `lf` is respected from the `.editorconfig` but my local git is configured to `checkoutout as Windows`. If I were to commit any formatted files, nothing would happen because git takes care of the conversion but you will always see formatted files as changed.

tl;dr : easier Fantomas / editorconfig integration when every F# file is checked out as `lf`.