### PR TITLE
Update ipynb metadata so that it works with new versions of polyglot notebook in VsCode

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+## 17.4.1
+
+* Update ipynb output metadata [#809](https://github.com/fsprojects/FSharp.Formatting/issues/809)
+
 ## 17.4.0
 
 * One FSI evaluator per docs file [#737](https://github.com/fsprojects/FSharp.Formatting/issues/737)

--- a/src/FSharp.Formatting.Common/PynbModel.fs
+++ b/src/FSharp.Formatting.Common/PynbModel.fs
@@ -55,7 +55,8 @@ type Cell =
     static member Default =
         { cell_type = "code"
           execution_count = None
-          metadata = """
+          metadata =
+            """
     "dotnet_interactive": {
      "language": "fsharp"
     },
@@ -170,12 +171,12 @@ type DefaultKernelInfo =
 
 type Metadata =
     { kernelspec: Kernelspec
-      language_info: LanguageInfo 
+      language_info: LanguageInfo
       defaultKernelInfo: DefaultKernelInfo }
 
     static member Default =
         { kernelspec = Kernelspec.Default
-          language_info = LanguageInfo.Default 
+          language_info = LanguageInfo.Default
           defaultKernelInfo = DefaultKernelInfo.Default }
 
     override this.ToString() =

--- a/tests/FSharp.Literate.Tests/LiterateTests.fs
+++ b/tests/FSharp.Literate.Tests/LiterateTests.fs
@@ -1065,7 +1065,9 @@ With some [hyperlink](http://tomasp.net)
     printfn "----"
     pynb |> shouldContainText """ "cells": ["""
 
-    pynb |> shouldContainText """ "cell_type": "markdown","""
+    pynb |> shouldContainText """
+   "cell_type": "markdown",
+   "metadata": {},"""
 
     pynb |> shouldContainText """ "source": ["Heading\n","""
 
@@ -1073,25 +1075,48 @@ With some [hyperlink](http://tomasp.net)
 
     pynb |> shouldContainText """With some [hyperlink](http://tomasp.net)"""
 
-    pynb |> shouldContainText """ "cell_type": "code","""
+    pynb |> shouldContainText """"cell_type": "code",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "fsharp"
+    },
+    "polyglot_notebook": {
+     "kernelName": "fsharp"
+    }"""
 
     pynb |> shouldContainText """ "execution_count": null, "outputs": [],"""
 
     pynb |> shouldContainText """ "source": ["let hello = \"Code sample"""
 
-    pynb
-    |> shouldContainText """ "kernelspec": {"display_name": ".NET (F#)", "language": "F#", "name": ".net-fsharp"},"""
+    pynb |> shouldContainText """  "kernelspec": {
+   "display_name": ".NET (F#)",
+   "language": "F#",
+   "name": ".net-fsharp"
+  },"""
+
+    pynb |> shouldContainText """"polyglot_notebook": {
+   "kernelInfo": {
+    "defaultKernelName": "fsharp",
+    "items": [
+     {
+      "aliases": [],
+      "languageName": "fsharp",
+      "name": "fsharp"
+     }
+    ]
+   }
+  }"""
 
     pynb |> shouldContainText """ "file_extension": ".fs","""
 
     pynb |> shouldContainText """ "mimetype": "text/x-fsharp","""
 
-    pynb |> shouldContainText """ "pygments_lexer": "fsharp","""
+    pynb |> shouldContainText """ "pygments_lexer": "fsharp"
+"""
 
-    pynb |> shouldContainText """ "version": "4.5"""
     pynb |> shouldContainText """ "nbformat": 4,"""
 
-    pynb |> shouldContainText """ "nbformat_minor": 1"""
+    pynb |> shouldContainText """ "nbformat_minor": 2"""
 
 
 [<Test>]
@@ -1258,25 +1283,49 @@ let hello5 = 4 // Doc preparation code is not present in generated notebooks
     pynb
     |> shouldNotContainText """Doc preparation code is not present in generated notebooks"""
 
-    pynb |> shouldContainText """ "cell_type": "code","""
-
-    pynb |> shouldContainText """ "execution_count": null, "outputs": [],"""
+    pynb |> shouldContainText """"cell_type": "code",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "fsharp"
+    },
+    "polyglot_notebook": {
+     "kernelName": "fsharp"
+    }
+   },
+   "execution_count": null, "outputs": [],"""
 
     pynb |> shouldContainText """ "source": ["let hello = \"Code sample"""
 
     pynb
-    |> shouldContainText """ "kernelspec": {"display_name": ".NET (F#)", "language": "F#", "name": ".net-fsharp"},"""
+    |> shouldContainText """  "kernelspec": {
+   "display_name": ".NET (F#)",
+   "language": "F#",
+   "name": ".net-fsharp"
+  },"""
+
+    pynb |> shouldContainText """  "polyglot_notebook": {
+   "kernelInfo": {
+    "defaultKernelName": "fsharp",
+    "items": [
+     {
+      "aliases": [],
+      "languageName": "fsharp",
+      "name": "fsharp"
+     }
+    ]
+   }
+  }"""
 
     pynb |> shouldContainText """ "file_extension": ".fs","""
 
     pynb |> shouldContainText """ "mimetype": "text/x-fsharp","""
 
-    pynb |> shouldContainText """ "pygments_lexer": "fsharp","""
+    pynb |> shouldContainText """ "pygments_lexer": "fsharp"
+"""
 
-    pynb |> shouldContainText """ "version": "4.5"""
     pynb |> shouldContainText """ "nbformat": 4,"""
 
-    pynb |> shouldContainText """ "nbformat_minor": 1"""
+    pynb |> shouldContainText """ "nbformat_minor": 2"""
 
 
 [<Test>]
@@ -1302,30 +1351,54 @@ let goodbye = 2
 
     let expected =
         """
-        {
-            "cells": [
-          {
-           "cell_type": "code",
-           "metadata": {},
-            "execution_count": null, "outputs": [],
-           "source": ["let hello = 1\n",
-"\n",
-"let goodbye = 2\n"]
-          }],
-            "metadata": {
-            "kernelspec": {"display_name": ".NET (F#)", "language": "F#", "name": ".net-fsharp"},
-            "langauge_info": {
-        "file_extension": ".fs",
-        "mimetype": "text/x-fsharp",
-        "name": "C#",
-        "pygments_lexer": "fsharp",
-        "version": "4.5"
-        }
-        },
-            "nbformat": 4,
-            "nbformat_minor": 1
-        }
-        """
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "fsharp"
+    },
+    "polyglot_notebook": {
+     "kernelName": "fsharp"
+    }
+   },
+   "execution_count": null, "outputs": [],
+   "source": [
+    "let hello = 1\n",
+    "\n",
+    "let goodbye = 2\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (F#)",
+   "language": "F#",
+   "name": ".net-fsharp"
+  },
+  "language_info": {
+   "file_extension": ".fs",
+   "mimetype": "text/x-fsharp",
+   "name": "polyglot-notebook",
+   "pygments_lexer": "fsharp"
+  },
+  "polyglot_notebook": {
+   "kernelInfo": {
+    "defaultKernelName": "fsharp",
+    "items": [
+     {
+      "aliases": [],
+      "languageName": "fsharp",
+      "name": "fsharp"
+     }
+    ]
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}"""
 
     let expected2 = expected.Replace("\r\n", "\n").Replace("\n", "!")
 

--- a/tests/FSharp.Literate.Tests/LiterateTests.fs
+++ b/tests/FSharp.Literate.Tests/LiterateTests.fs
@@ -1065,18 +1065,24 @@ With some [hyperlink](http://tomasp.net)
     printfn "----"
     pynb |> shouldContainText """ "cells": ["""
 
-    pynb |> shouldContainText """
+    pynb
+    |> shouldContainText
+        """
    "cell_type": "markdown",
    "metadata": {},"""
 
-    pynb |> shouldContainText """ "source": [
+    pynb
+    |> shouldContainText
+        """ "source": [
     "Heading\n","""
 
     pynb |> shouldContainText """"=======\n","""
 
     pynb |> shouldContainText """With some [hyperlink](http://tomasp.net)"""
 
-    pynb |> shouldContainText """"cell_type": "code",
+    pynb
+    |> shouldContainText
+        """"cell_type": "code",
    "metadata": {
     "dotnet_interactive": {
      "language": "fsharp"
@@ -1087,16 +1093,22 @@ With some [hyperlink](http://tomasp.net)
 
     pynb |> shouldContainText """ "execution_count": null, "outputs": [],"""
 
-    pynb |> shouldContainText """ "source": [
+    pynb
+    |> shouldContainText
+        """ "source": [
     "let hello = \"Code sample"""
 
-    pynb |> shouldContainText """  "kernelspec": {
+    pynb
+    |> shouldContainText
+        """  "kernelspec": {
    "display_name": ".NET (F#)",
    "language": "F#",
    "name": ".net-fsharp"
   },"""
 
-    pynb |> shouldContainText """"polyglot_notebook": {
+    pynb
+    |> shouldContainText
+        """"polyglot_notebook": {
    "kernelInfo": {
     "defaultKernelName": "fsharp",
     "items": [
@@ -1113,7 +1125,9 @@ With some [hyperlink](http://tomasp.net)
 
     pynb |> shouldContainText """ "mimetype": "text/x-fsharp","""
 
-    pynb |> shouldContainText """ "pygments_lexer": "fsharp"
+    pynb
+    |> shouldContainText
+        """ "pygments_lexer": "fsharp"
 """
 
     pynb |> shouldContainText """ "nbformat": 4,"""
@@ -1210,7 +1224,9 @@ let hello5 = 4 // Doc preparation code is not present in generated notebooks
 
     pynb |> shouldContainText """ "cell_type": "markdown","""
 
-    pynb |> shouldContainText """ "source": [
+    pynb
+    |> shouldContainText
+        """ "source": [
     "Heading"""
 
     pynb |> shouldContainText """====="""
@@ -1286,7 +1302,9 @@ let hello5 = 4 // Doc preparation code is not present in generated notebooks
     pynb
     |> shouldNotContainText """Doc preparation code is not present in generated notebooks"""
 
-    pynb |> shouldContainText """"cell_type": "code",
+    pynb
+    |> shouldContainText
+        """"cell_type": "code",
    "metadata": {
     "dotnet_interactive": {
      "language": "fsharp"
@@ -1297,17 +1315,22 @@ let hello5 = 4 // Doc preparation code is not present in generated notebooks
    },
    "execution_count": null, "outputs": [],"""
 
-    pynb |> shouldContainText """ "source": [
+    pynb
+    |> shouldContainText
+        """ "source": [
     "let hello = \"Code sample"""
 
     pynb
-    |> shouldContainText """  "kernelspec": {
+    |> shouldContainText
+        """  "kernelspec": {
    "display_name": ".NET (F#)",
    "language": "F#",
    "name": ".net-fsharp"
   },"""
 
-    pynb |> shouldContainText """  "polyglot_notebook": {
+    pynb
+    |> shouldContainText
+        """  "polyglot_notebook": {
    "kernelInfo": {
     "defaultKernelName": "fsharp",
     "items": [
@@ -1324,7 +1347,9 @@ let hello5 = 4 // Doc preparation code is not present in generated notebooks
 
     pynb |> shouldContainText """ "mimetype": "text/x-fsharp","""
 
-    pynb |> shouldContainText """ "pygments_lexer": "fsharp"
+    pynb
+    |> shouldContainText
+        """ "pygments_lexer": "fsharp"
 """
 
     pynb |> shouldContainText """ "nbformat": 4,"""

--- a/tests/FSharp.Literate.Tests/LiterateTests.fs
+++ b/tests/FSharp.Literate.Tests/LiterateTests.fs
@@ -1069,7 +1069,8 @@ With some [hyperlink](http://tomasp.net)
    "cell_type": "markdown",
    "metadata": {},"""
 
-    pynb |> shouldContainText """ "source": ["Heading\n","""
+    pynb |> shouldContainText """ "source": [
+    "Heading\n","""
 
     pynb |> shouldContainText """"=======\n","""
 
@@ -1086,7 +1087,8 @@ With some [hyperlink](http://tomasp.net)
 
     pynb |> shouldContainText """ "execution_count": null, "outputs": [],"""
 
-    pynb |> shouldContainText """ "source": ["let hello = \"Code sample"""
+    pynb |> shouldContainText """ "source": [
+    "let hello = \"Code sample"""
 
     pynb |> shouldContainText """  "kernelspec": {
    "display_name": ".NET (F#)",
@@ -1208,7 +1210,8 @@ let hello5 = 4 // Doc preparation code is not present in generated notebooks
 
     pynb |> shouldContainText """ "cell_type": "markdown","""
 
-    pynb |> shouldContainText """ "source": ["Heading"""
+    pynb |> shouldContainText """ "source": [
+    "Heading"""
 
     pynb |> shouldContainText """====="""
     pynb |> shouldContainText """```emptyblockcode"""
@@ -1294,7 +1297,8 @@ let hello5 = 4 // Doc preparation code is not present in generated notebooks
    },
    "execution_count": null, "outputs": [],"""
 
-    pynb |> shouldContainText """ "source": ["let hello = \"Code sample"""
+    pynb |> shouldContainText """ "source": [
+    "let hello = \"Code sample"""
 
     pynb
     |> shouldContainText """  "kernelspec": {


### PR DESCRIPTION
This fixes #809 by adding additional metadata that is now expected by the VS Code polyglot notebooks extension (formerly known as dotnet interactive extension). See the issue for further info.

I've tested this in VS Code and VS Code insiders.

I added F# metadata for code cells to prevent them being mistaken for C# cells. For notebook metadata I made F# the default notebook language. These issues were not present in earlier versions of polyglot notebooks, but now there's problems for F# notebooks if this metadata is not set.

(sorry for the commit history; something weird happened when I tried to update from the main branch).