### PR TITLE
Pass `--multiemit-` as default option for FsiEvaluator.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+## 18.0.1
+
+* Pass `--multiemit-` as default option for `FsiEvaluator`.
+
 ## 18.0.0
 
 * Update FCS to 43.7.200

--- a/src/fsdocs-tool/BuildCommand.fs
+++ b/src/fsdocs-tool/BuildCommand.fs
@@ -254,7 +254,9 @@ type internal DocContent
 
                           let fsiEvaluator =
                               (if evaluate then
-                                   Some(FsiEvaluator(onError = onError) :> IFsiEvaluator)
+                                   Some(
+                                       FsiEvaluator(onError = onError, options = [| "--multiemit-" |]) :> IFsiEvaluator
+                                   )
                                else
                                    None)
 


### PR DESCRIPTION
After updating to v18 in Fantomas, we noticed that Linux is no longer processing `(*** include-output ***)`.

When locally (in WSL) adding `--multiemit-` to `FsiEvaluator` is started working again.
I propose we ship this out of the box.

Thoughts @baronfel?