### PR TITLE
Memberdocs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,3 +15,6 @@ trim_trailing_whitespace = true
 fsharp_max_array_or_list_width=120
 fsharp_max_infix_operator_expression=80
 fsharp_max_value_binding_width=120
+
+[GenerateHtml.fs]
+fsharp_experimental_elmish = true

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ See https://fsprojects.github.io/FSharp.Formatting/
 Once built, you can run the command-line tool to self-build the docs for this directory using 
 
     dotnet build
-    src\fsdocs-tool\bin\Debug\net7.0\fsdocs.exe watch
-    src\fsdocs-tool\bin\Debug\net7.0\fsdocs.exe build --clean
+    src\fsdocs-tool\bin\Debug\net6.0\fsdocs.exe watch
+    src\fsdocs-tool\bin\Debug\net6.0\fsdocs.exe build --clean
 
 
 ## Maintainer(s)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 ## 18.1.0
 
-* Condense ApiDocs member info [#778](https://github.com/fsprojects/FSharp.Formatting/issues/778). The issue was fixed collaboratively online in an [Amplifying F# session](https://amplifying-fsharp.github.io/) with a recording that can be found [here](https://amplifying-fsharp.github.io/sessions/2023/03/31/).
+* Collapsible ApiDocs member info [#778](https://github.com/fsprojects/FSharp.Formatting/issues/778). The issue was fixed collaboratively in an [Amplifying F# session](https://amplifying-fsharp.github.io/) with a recording that can be found [here](https://amplifying-fsharp.github.io/sessions/2023/03/31/).
 
 ## 18.0.0
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+## 18.1.0
+
+* Condense ApiDocs member info [#778](https://github.com/fsprojects/FSharp.Formatting/issues/778)
+
 ## 18.0.0
 
 * Update FCS to 43.7.200

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 ## 18.1.0
 
-* Condense ApiDocs member info [#778](https://github.com/fsprojects/FSharp.Formatting/issues/778)
+* Condense ApiDocs member info [#778](https://github.com/fsprojects/FSharp.Formatting/issues/778). The issue was fixed collaboratively online in an [Amplifying F# session](https://amplifying-fsharp.github.io/) with a recording that can be found [here](https://amplifying-fsharp.github.io/sessions/2023/03/31/).
 
 ## 18.0.0
 

--- a/docs/content/fsdocs-default.css
+++ b/docs/content/fsdocs-default.css
@@ -252,7 +252,7 @@ blockquote {
     margin: 10px 0px 0px 0px;
 }
 
-.fsdocs-member-xmldoc details[open] dl {
+.fsdocs-member-xmldoc details[open] summary + * {
     margin-top: 1rem;
 }
 

--- a/docs/content/fsdocs-default.css
+++ b/docs/content/fsdocs-default.css
@@ -225,6 +225,10 @@ blockquote {
   Formatting xmldoc sections in fsdocs-content
 /*--------------------------------------------------------------------------*/
 
+.fsdocs-summary {
+    display: inline;
+}
+
 .fsdocs-xmldoc, .fsdocs-entity-xmldoc, .fsdocs-member-xmldoc {
     font-size: 1.0rem;
     line-height: 1.375rem;

--- a/docs/content/fsdocs-default.css
+++ b/docs/content/fsdocs-default.css
@@ -252,6 +252,10 @@ blockquote {
     margin: 10px 0px 0px 0px;
 }
 
+.fsdocs-member-xmldoc details[open] dl {
+    margin-top: 1rem;
+}
+
 /* #fsdocs-nav .searchbox {
     margin-top: 30px;
     margin-bottom: 30px;

--- a/src/FSharp.Formatting.ApiDocs/GenerateHtml.fs
+++ b/src/FSharp.Formatting.ApiDocs/GenerateHtml.fs
@@ -267,12 +267,14 @@ type HtmlRender(model: ApiDocModel, ?menuTemplateFolder: string) =
                                     //    p [] [!!"CompiledName: "; code [] [!!m.Details.FormatCompiledName]]
                                     ]
 
-                              td
-                                  [ Class "fsdocs-member-xmldoc" ]
-                                  (match dtls, m.Comment.Summary.HtmlText.Trim() with
-                                   | [], _ -> [ smry ]
-                                   | _, "" -> dtls
-                                   | _, _ -> [ details [] ((summary [] [ smry ]) :: dtls) ])
+                              td [ Class "fsdocs-member-xmldoc" ] [
+                                  if List.isEmpty dtls then
+                                      smry
+                                  elif String.IsNullOrWhiteSpace(m.Comment.Summary.HtmlText) then
+                                      yield! dtls
+                                  else
+                                      details [] ((summary [] [ smry ]) :: dtls)
+                              ]
                           ]
                   ]
               ] ]

--- a/src/FSharp.Formatting.ApiDocs/GenerateHtml.fs
+++ b/src/FSharp.Formatting.ApiDocs/GenerateHtml.fs
@@ -31,25 +31,25 @@ type HtmlRender(model: ApiDocModel, ?menuTemplateFolder: string) =
         uniqueNumber
 
     let codeWithToolTip content tip =
-        div
-            []
-            [ let id = UniqueID().ToString()
+        div [] [
+            let id = UniqueID().ToString()
 
-              code
-                  [ OnMouseOut(sprintf "hideTip(event, '%s', %s)" id id)
-                    OnMouseOver(sprintf "showTip(event, '%s', %s)" id id) ]
-                  content
+            code
+                [ OnMouseOut(sprintf "hideTip(event, '%s', %s)" id id)
+                  OnMouseOver(sprintf "showTip(event, '%s', %s)" id id) ]
+                content
 
-              div [ Class "fsdocs-tip"; Id id ] tip ]
+            div [ Class "fsdocs-tip"; Id id ] tip
+        ]
 
     let sourceLink url =
         [ match url with
           | None -> ()
           | Some href ->
-              a
-                  [ Href href; Class "fsdocs-source-link"; HtmlProperties.Title "Source on GitHub" ]
-                  [ img [ Src(sprintf "%scontent/img/github.png" root); Class "normal" ]
-                    img [ Src(sprintf "%scontent/img/github-hover.png" root); Class "hover" ] ] ]
+              a [ Href href; Class "fsdocs-source-link"; HtmlProperties.Title "Source on GitHub" ] [
+                  img [ Src(sprintf "%scontent/img/github.png" root); Class "normal" ]
+                  img [ Src(sprintf "%scontent/img/github-hover.png" root); Class "hover" ]
+              ] ]
 
     let removeParen (memberName: string) =
         let firstParen = memberName.IndexOf("(")
@@ -61,12 +61,14 @@ type HtmlRender(model: ApiDocModel, ?menuTemplateFolder: string) =
 
     // Copy XML sig for use in `cref` XML
     let copyXmlSigIcon xmlDocSig =
-        div
-            [ Class "fsdocs-source-link"
-              HtmlProperties.Title "Copy signature (XML)"
-              OnClick(sprintf "Clipboard_CopyTo('<see cref=\\\'%s\\\'/>')" xmlDocSig) ]
-            [ img [ Src(sprintf "%scontent/img/copy-xml.png" root); Class "normal" ]
-              img [ Src(sprintf "%scontent/img/copy-xml-hover.png" root); Class "hover" ] ]
+        div [
+            Class "fsdocs-source-link"
+            HtmlProperties.Title "Copy signature (XML)"
+            OnClick(sprintf "Clipboard_CopyTo('<see cref=\\\'%s\\\'/>')" xmlDocSig)
+        ] [
+            img [ Src(sprintf "%scontent/img/copy-xml.png" root); Class "normal" ]
+            img [ Src(sprintf "%scontent/img/copy-xml-hover.png" root); Class "hover" ]
+        ]
 
     let copyXmlSigIconForSymbol (symbol: FSharpSymbol) =
         [ match symbol with
@@ -84,12 +86,14 @@ type HtmlRender(model: ApiDocModel, ?menuTemplateFolder: string) =
                 elif xmlDocSig.Contains("`") then "``"
                 else "`"
 
-            div
-                [ Class "fsdocs-source-link"
-                  HtmlProperties.Title "Copy signature (Markdown)"
-                  OnClick(sprintf "Clipboard_CopyTo('%scref:%s%s')" delim xmlDocSig delim) ]
-                [ img [ Src(sprintf "%scontent/img/copy-md.png" root); Class "normal" ]
-                  img [ Src(sprintf "%scontent/img/copy-md-hover.png" root); Class "hover" ] ]
+            div [
+                Class "fsdocs-source-link"
+                HtmlProperties.Title "Copy signature (Markdown)"
+                OnClick(sprintf "Clipboard_CopyTo('%scref:%s%s')" delim xmlDocSig delim)
+            ] [
+                img [ Src(sprintf "%scontent/img/copy-md.png" root); Class "normal" ]
+                img [ Src(sprintf "%scontent/img/copy-md-hover.png" root); Class "hover" ]
+            ]
 
     let copyXmlSigIconForSymbolMarkdown (symbol: FSharpSymbol) =
         [ match symbol with
@@ -101,176 +105,177 @@ type HtmlRender(model: ApiDocModel, ?menuTemplateFolder: string) =
         [ if members.Length > 0 then
               h3 [] [ !!header ]
 
-              table
-                  [ Class "table outer-list fsdocs-member-list" ]
-                  [ thead
-                        []
-                        [ tr
-                              []
-                              [ td [ Class "fsdocs-member-list-header" ] [ !!tableHeader ]
-                                td [ Class "fsdocs-member-list-header" ] [ !! "Description" ] ] ]
-                    tbody
-                        []
-                        [ for m in members do
-                              tr
-                                  []
-                                  [ td
-                                        [ Class "fsdocs-member-usage" ]
-                                        [
+              table [ Class "table outer-list fsdocs-member-list" ] [
+                  thead [] [
+                      tr [] [
+                          td [ Class "fsdocs-member-list-header" ] [ !!tableHeader ]
+                          td [ Class "fsdocs-member-list-header" ] [ !! "Description" ]
+                      ]
+                  ]
+                  tbody [] [
+                      for m in members do
+                          tr [] [
+                              td [ Class "fsdocs-member-usage" ] [
 
-                                          codeWithToolTip
-                                              [
-                                                // This adds #MemberName anchor. These may be ambiguous due to overloading
-                                                p
-                                                    []
-                                                    [ a [ Id m.Name ] [ a [ Href("#" + m.Name) ] [ embed m.UsageHtml ] ] ] ]
-                                              [ div
-                                                    [ Class "member-tooltip" ]
-                                                    [ !! "Full Usage: "
-                                                      embed m.UsageHtml
-                                                      br []
-                                                      br []
-                                                      if not m.Parameters.IsEmpty then
-                                                          !! "Parameters: "
-
-                                                          ul
-                                                              []
-                                                              [ for p in m.Parameters do
-                                                                    span
-                                                                        []
-                                                                        [ b [] [ !!p.ParameterNameText ]
-                                                                          !! ":"
-                                                                          embed p.ParameterType
-                                                                          match p.ParameterDocs with
-                                                                          | None -> ()
-                                                                          | Some d ->
-                                                                              !! " - "
-                                                                              embed d ]
-
-                                                                    br [] ]
-
-                                                          br []
-                                                      match m.ReturnInfo.ReturnType with
-                                                      | None -> ()
-                                                      | Some(_, rty) ->
-                                                          span
-                                                              []
-                                                              [ !!(if m.Kind <> ApiDocMemberKind.RecordField then
-                                                                       "Returns: "
-                                                                   else
-                                                                       "Field type: ")
-                                                                embed rty ]
-
-                                                          match m.ReturnInfo.ReturnDocs with
-                                                          | None -> ()
-                                                          | Some d -> embed d
-
-                                                          br []
-                                                      //!! "Signature: "
-                                                      //encode(m.SignatureTooltip)
-                                                      if not m.Modifiers.IsEmpty then
-                                                          !! "Modifiers: "
-                                                          encode (m.FormatModifiers)
-                                                          br []
-
-                                                          // We suppress the display of ill-formatted type parameters for places
-                                                          // where these have not been explicitly declared
-                                                          match m.FormatTypeArguments with
-                                                          | None -> ()
-                                                          | Some v ->
-                                                              !! "Type parameters: "
-                                                              encode (v) ] ] ]
-
-                                    td
-                                        [ Class "fsdocs-member-xmldoc" ]
-                                        [ div
-                                              [ Class "fsdocs-summary" ]
-                                              [ yield! copyXmlSigIconForSymbolMarkdown m.Symbol
-                                                yield! copyXmlSigIconForSymbol m.Symbol
-                                                yield! sourceLink m.SourceLocation
-                                                p [ Class "fsdocs-summary" ] [ embed m.Comment.Summary ] ]
-
-                                          match m.Comment.Remarks with
-                                          | Some r -> p [ Class "fsdocs-remarks" ] [ embed r ]
-                                          | None -> ()
-
-                                          match m.ExtendedType with
-                                          | Some(_, extendedTypeHtml) ->
-                                              p [] [ !! "Extended Type: "; embed extendedTypeHtml ]
-                                          | _ -> ()
-
+                                  codeWithToolTip [
+                                      // This adds #MemberName anchor. These may be ambiguous due to overloading
+                                      p [] [ a [ Id m.Name ] [ a [ Href("#" + m.Name) ] [ embed m.UsageHtml ] ] ]
+                                  ] [
+                                      div [ Class "member-tooltip" ] [
+                                          !! "Full Usage: "
+                                          embed m.UsageHtml
+                                          br []
+                                          br []
                                           if not m.Parameters.IsEmpty then
-                                              dl
-                                                  [ Class "fsdocs-params" ]
-                                                  [ for parameter in m.Parameters do
-                                                        dt
-                                                            [ Class "fsdocs-param" ]
-                                                            [ span
-                                                                  [ Class "fsdocs-param-name" ]
-                                                                  [ !!parameter.ParameterNameText ]
-                                                              !! ":"
-                                                              embed parameter.ParameterType ]
+                                              !! "Parameters: "
 
-                                                        dd
-                                                            [ Class "fsdocs-param-docs" ]
-                                                            [ match parameter.ParameterDocs with
-                                                              | None -> ()
-                                                              | Some d -> p [] [ embed d ] ] ]
+                                              ul [] [
+                                                  for p in m.Parameters do
+                                                      span [] [
+                                                          b [] [ !!p.ParameterNameText ]
+                                                          !! ":"
+                                                          embed p.ParameterType
+                                                          match p.ParameterDocs with
+                                                          | None -> ()
+                                                          | Some d ->
+                                                              !! " - "
+                                                              embed d
+                                                      ]
 
+                                                      br []
+                                              ]
+
+                                              br []
                                           match m.ReturnInfo.ReturnType with
                                           | None -> ()
-                                          | Some(_, returnTypeHtml) ->
-                                              dl
-                                                  [ Class "fsdocs-returns" ]
-                                                  [ dt
-                                                        []
-                                                        [ span
-                                                              [ Class "fsdocs-return-name" ]
-                                                              [ !!(if m.Kind <> ApiDocMemberKind.RecordField then
-                                                                       "Returns: "
-                                                                   else
-                                                                       "Field type: ") ]
-                                                          embed returnTypeHtml ]
-                                                    dd
-                                                        [ Class "fsdocs-return-docs" ]
-                                                        [ match m.ReturnInfo.ReturnDocs with
-                                                          | None -> ()
-                                                          | Some r -> p [] [ embed r ] ] ]
+                                          | Some(_, rty) ->
+                                              span [] [
+                                                  !!(if m.Kind <> ApiDocMemberKind.RecordField then
+                                                         "Returns: "
+                                                     else
+                                                         "Field type: ")
+                                                  embed rty
+                                              ]
 
-                                          if not m.Comment.Exceptions.IsEmpty then
-                                              //p [] [ !! "Exceptions:" ]
-                                              table
-                                                  [ Class "fsdocs-exception-list" ]
-                                                  [ for (nm, link, html) in m.Comment.Exceptions do
-                                                        tr
-                                                            []
-                                                            [ td
-                                                                  []
-                                                                  (match link with
-                                                                   | None -> []
-                                                                   | Some href -> [ a [ Href href ] [ !!nm ] ])
-                                                              td [] [ embed html ] ] ]
+                                              match m.ReturnInfo.ReturnDocs with
+                                              | None -> ()
+                                              | Some d -> embed d
 
-                                          for e in m.Comment.Notes do
-                                              h5 [ Class "fsdocs-note-header" ] [ !! "Note" ]
+                                              br []
+                                          //!! "Signature: "
+                                          //encode(m.SignatureTooltip)
+                                          if not m.Modifiers.IsEmpty then
+                                              !! "Modifiers: "
+                                              encode (m.FormatModifiers)
+                                              br []
 
-                                              p [ Class "fsdocs-note" ] [ embed e ]
+                                              // We suppress the display of ill-formatted type parameters for places
+                                              // where these have not been explicitly declared
+                                              match m.FormatTypeArguments with
+                                              | None -> ()
+                                              | Some v ->
+                                                  !! "Type parameters: "
+                                                  encode (v)
+                                      ]
+                                  ]
+                              ]
 
-                                          for e in m.Comment.Examples do
-                                              h5 [ Class "fsdocs-example-header" ] [ !! "Example" ]
+                              td [ Class "fsdocs-member-xmldoc" ] [
+                                  details [] [
+                                      summary [] [
+                                          div [ Class "fsdocs-summary" ] [
+                                              yield! copyXmlSigIconForSymbolMarkdown m.Symbol
+                                              yield! copyXmlSigIconForSymbol m.Symbol
+                                              yield! sourceLink m.SourceLocation
+                                              p [ Class "fsdocs-summary" ] [ embed m.Comment.Summary ]
+                                          ]
+                                      ]
 
-                                              p
-                                                  [ Class "fsdocs-example"
-                                                    if e.Id.IsSome then
-                                                        Id e.Id.Value ]
-                                                  [ embed e ]
+                                      match m.Comment.Remarks with
+                                      | Some r -> p [ Class "fsdocs-remarks" ] [ embed r ]
+                                      | None -> ()
 
-                                          //if m.IsObsolete then
-                                          //    obsoleteMessage m.ObsoleteMessage
+                                      match m.ExtendedType with
+                                      | Some(_, extendedTypeHtml) ->
+                                          p [] [ !! "Extended Type: "; embed extendedTypeHtml ]
+                                      | _ -> ()
 
-                                          //if not (String.IsNullOrEmpty(m.Details.FormatCompiledName)) then
-                                          //    p [] [!!"CompiledName: "; code [] [!!m.Details.FormatCompiledName]]
-                                          ] ] ] ] ]
+                                      if not m.Parameters.IsEmpty then
+                                          dl [ Class "fsdocs-params" ] [
+                                              for parameter in m.Parameters do
+                                                  dt [ Class "fsdocs-param" ] [
+                                                      span [ Class "fsdocs-param-name" ] [
+                                                          !!parameter.ParameterNameText
+                                                      ]
+                                                      !! ":"
+                                                      embed parameter.ParameterType
+                                                  ]
+
+                                                  dd [ Class "fsdocs-param-docs" ] [
+                                                      match parameter.ParameterDocs with
+                                                      | None -> ()
+                                                      | Some d -> p [] [ embed d ]
+                                                  ]
+                                          ]
+
+                                      match m.ReturnInfo.ReturnType with
+                                      | None -> ()
+                                      | Some(_, returnTypeHtml) ->
+                                          dl [ Class "fsdocs-returns" ] [
+                                              dt [] [
+                                                  span [ Class "fsdocs-return-name" ] [
+                                                      !!(if m.Kind <> ApiDocMemberKind.RecordField then
+                                                             "Returns: "
+                                                         else
+                                                             "Field type: ")
+                                                  ]
+                                                  embed returnTypeHtml
+                                              ]
+                                              dd [ Class "fsdocs-return-docs" ] [
+                                                  match m.ReturnInfo.ReturnDocs with
+                                                  | None -> ()
+                                                  | Some r -> p [] [ embed r ]
+                                              ]
+                                          ]
+
+                                      if not m.Comment.Exceptions.IsEmpty then
+                                          //p [] [ !! "Exceptions:" ]
+                                          table [ Class "fsdocs-exception-list" ] [
+                                              for (nm, link, html) in m.Comment.Exceptions do
+                                                  tr [] [
+                                                      td
+                                                          []
+                                                          (match link with
+                                                           | None -> []
+                                                           | Some href -> [ a [ Href href ] [ !!nm ] ])
+                                                      td [] [ embed html ]
+                                                  ]
+                                          ]
+
+                                      for e in m.Comment.Notes do
+                                          h5 [ Class "fsdocs-note-header" ] [ !! "Note" ]
+
+                                          p [ Class "fsdocs-note" ] [ embed e ]
+
+                                      for e in m.Comment.Examples do
+                                          h5 [ Class "fsdocs-example-header" ] [ !! "Example" ]
+
+                                          p [
+                                              Class "fsdocs-example"
+                                              if e.Id.IsSome then
+                                                  Id e.Id.Value
+                                          ] [ embed e ]
+
+                                  //if m.IsObsolete then
+                                  //    obsoleteMessage m.ObsoleteMessage
+
+                                  //if not (String.IsNullOrEmpty(m.Details.FormatCompiledName)) then
+                                  //    p [] [!!"CompiledName: "; code [] [!!m.Details.FormatCompiledName]]
+                                  ]
+                              ]
+                          ]
+                  ]
+              ] ]
 
     let renderEntities (entities: ApiDocEntity list) =
         [ if entities.Length > 0 then
@@ -278,62 +283,54 @@ type HtmlRender(model: ApiDocModel, ?menuTemplateFolder: string) =
 
               let hasModules = entities |> List.exists (fun e -> not e.IsTypeDefinition)
 
-              table
-                  [ Class "table outer-list fsdocs-entity-list" ]
-                  [ thead
-                        []
-                        [ tr
-                              []
-                              [ td
-                                    []
-                                    [ !!(if hasTypes && hasModules then "Type/Module"
-                                         elif hasTypes then "Type"
-                                         else "Modules") ]
-                                td [] [ !! "Description" ] ] ]
-                    tbody
-                        []
-                        [ for e in entities do
-                              tr
-                                  []
-                                  [ td
-                                        [ Class "fsdocs-entity-name" ]
-                                        [ let nm = e.Name
+              table [ Class "table outer-list fsdocs-entity-list" ] [
+                  thead [] [
+                      tr [] [
+                          td [] [
+                              !!(if hasTypes && hasModules then "Type/Module"
+                                 elif hasTypes then "Type"
+                                 else "Modules")
+                          ]
+                          td [] [ !! "Description" ]
+                      ]
+                  ]
+                  tbody [] [
+                      for e in entities do
+                          tr [] [
+                              td [ Class "fsdocs-entity-name" ] [
+                                  let nm = e.Name
 
-                                          let multi =
-                                              (entities |> List.filter (fun e -> e.Name = nm) |> List.length) > 1
+                                  let multi = (entities |> List.filter (fun e -> e.Name = nm) |> List.length) > 1
 
-                                          let nmWithSiffix =
-                                              if multi then
-                                                  (if e.IsTypeDefinition then
-                                                       nm + " (Type)"
-                                                   else
-                                                       nm + " (Module)")
-                                              else
-                                                  nm
+                                  let nmWithSiffix =
+                                      if multi then
+                                          (if e.IsTypeDefinition then
+                                               nm + " (Type)"
+                                           else
+                                               nm + " (Module)")
+                                      else
+                                          nm
 
-                                          // This adds #EntityName anchor. These may currently be ambiguous
-                                          p
-                                              []
-                                              [ a
-                                                    [ Name nm ]
-                                                    [ a
-                                                          [ Href(
-                                                                e.Url(
-                                                                    root,
-                                                                    collectionName,
-                                                                    qualify,
-                                                                    model.FileExtensions.InUrl
-                                                                )
-                                                            ) ]
-                                                          [ !!nmWithSiffix ] ] ] ]
-                                    td
-                                        [ Class "fsdocs-entity-xmldoc" ]
-                                        [ div
-                                              []
-                                              [ yield! copyXmlSigIconForSymbolMarkdown e.Symbol
-                                                yield! copyXmlSigIconForSymbol e.Symbol
-                                                yield! sourceLink e.SourceLocation
-                                                p [ Class "fsdocs-summary" ] [ embed e.Comment.Summary ] ] ] ] ] ] ]
+                                  // This adds #EntityName anchor. These may currently be ambiguous
+                                  p [] [
+                                      a [ Name nm ] [
+                                          a [ Href(e.Url(root, collectionName, qualify, model.FileExtensions.InUrl)) ] [
+                                              !!nmWithSiffix
+                                          ]
+                                      ]
+                                  ]
+                              ]
+                              td [ Class "fsdocs-entity-xmldoc" ] [
+                                  div [] [
+                                      yield! copyXmlSigIconForSymbolMarkdown e.Symbol
+                                      yield! copyXmlSigIconForSymbol e.Symbol
+                                      yield! sourceLink e.SourceLocation
+                                      p [ Class "fsdocs-summary" ] [ embed e.Comment.Summary ]
+                                  ]
+                              ]
+                          ]
+                  ]
+              ] ]
 
     let entityContent (info: ApiDocEntityInfo) =
         // Get all the members & comment for the type
@@ -349,117 +346,114 @@ type HtmlRender(model: ApiDocModel, ?menuTemplateFolder: string) =
             | _ -> entity.Name
 
         [ h2 [] [ !!(usageName + (if entity.IsTypeDefinition then " Type" else " Module")) ]
-          dl
-              [ Class "fsdocs-metadata" ]
-              [ dt
-                    []
-                    [ !! "Namespace: "
-                      a
-                          [ Href(info.Namespace.Url(root, collectionName, qualify, model.FileExtensions.InUrl)) ]
-                          [ !!info.Namespace.Name ] ]
-                dt [] [ !!("Assembly: " + entity.Assembly.Name + ".dll") ]
+          dl [ Class "fsdocs-metadata" ] [
+              dt [] [
+                  !! "Namespace: "
+                  a [ Href(info.Namespace.Url(root, collectionName, qualify, model.FileExtensions.InUrl)) ] [
+                      !!info.Namespace.Name
+                  ]
+              ]
+              dt [] [ !!("Assembly: " + entity.Assembly.Name + ".dll") ]
 
-                match info.ParentModule with
-                | None -> ()
-                | Some parentModule ->
-                    dt
-                        []
-                        [ !! "Parent Module: "
-                          a
-                              [ Href(parentModule.Url(root, collectionName, qualify, model.FileExtensions.InUrl)) ]
-                              [ !!parentModule.Name ] ]
+              match info.ParentModule with
+              | None -> ()
+              | Some parentModule ->
+                  dt [] [
+                      !! "Parent Module: "
+                      a [ Href(parentModule.Url(root, collectionName, qualify, model.FileExtensions.InUrl)) ] [
+                          !!parentModule.Name
+                      ]
+                  ]
 
 
-                match entity.AbbreviatedType with
-                | Some(_, abbreviatedTypHtml) -> dt [] [ !! "Abbreviation For: "; embed abbreviatedTypHtml ]
+              match entity.AbbreviatedType with
+              | Some(_, abbreviatedTypHtml) -> dt [] [ !! "Abbreviation For: "; embed abbreviatedTypHtml ]
 
-                | None -> ()
+              | None -> ()
 
-                match entity.BaseType with
-                | Some(_, baseTypeHtml) -> dt [] [ !! "Base Type: "; embed baseTypeHtml ]
-                | None -> ()
+              match entity.BaseType with
+              | Some(_, baseTypeHtml) -> dt [] [ !! "Base Type: "; embed baseTypeHtml ]
+              | None -> ()
 
-                match entity.AllInterfaces with
-                | [] -> ()
-                | l ->
-                    dt
-                        []
-                        [ !!("All Interfaces: ")
-                          for (i, (_, ityHtml)) in Seq.indexed l do
-                              if i <> 0 then
-                                  !! ", "
+              match entity.AllInterfaces with
+              | [] -> ()
+              | l ->
+                  dt [] [
+                      !!("All Interfaces: ")
+                      for (i, (_, ityHtml)) in Seq.indexed l do
+                          if i <> 0 then
+                              !! ", "
 
-                              embed ityHtml ]
+                          embed ityHtml
+                  ]
 
-                if entity.Symbol.IsValueType then
-                    dt [] [ !!("Kind: Struct") ]
+              if entity.Symbol.IsValueType then
+                  dt [] [ !!("Kind: Struct") ]
 
-                match entity.DelegateSignature with
-                | Some(_, delegateSigHtml) -> dt [] [ !!("Delegate Signature: "); embed delegateSigHtml ]
-                | None -> ()
+              match entity.DelegateSignature with
+              | Some(_, delegateSigHtml) -> dt [] [ !!("Delegate Signature: "); embed delegateSigHtml ]
+              | None -> ()
 
-                if entity.Symbol.IsProvided then
-                    dt [] [ !!("This is a provided type definition") ]
+              if entity.Symbol.IsProvided then
+                  dt [] [ !!("This is a provided type definition") ]
 
-                if entity.Symbol.IsAttributeType then
-                    dt [] [ !!("This is an attribute type definition") ]
+              if entity.Symbol.IsAttributeType then
+                  dt [] [ !!("This is an attribute type definition") ]
 
-                if entity.Symbol.IsEnum then
-                    dt [] [ !!("This is an enum type definition") ]
+              if entity.Symbol.IsEnum then
+                  dt [] [ !!("This is an enum type definition") ]
 
-                //if info.Entity.IsObsolete then
-                //    obsoleteMessage entity.ObsoleteMessage
-                ]
+          //if info.Entity.IsObsolete then
+          //    obsoleteMessage entity.ObsoleteMessage
+          ]
           // Show the summary (and sectioned docs without any members)
-          div
-              [ Class "fsdocs-xmldoc" ]
-              [ div
-                    []
-                    [
-                      //yield! copyXmlSigIconForSymbol entity.Symbol
-                      //yield! sourceLink entity.SourceLocation
-                      p [ Class "fsdocs-summary" ] [ embed entity.Comment.Summary ] ]
-                // Show the remarks etc.
-                match entity.Comment.Remarks with
-                | Some r -> p [ Class "fsdocs-remarks" ] [ embed r ]
-                | None -> ()
-                for note in entity.Comment.Notes do
-                    h5 [ Class "fsdocs-note-header" ] [ !! "Note" ]
+          div [ Class "fsdocs-xmldoc" ] [
+              div [] [
+                  //yield! copyXmlSigIconForSymbol entity.Symbol
+                  //yield! sourceLink entity.SourceLocation
+                  p [ Class "fsdocs-summary" ] [ embed entity.Comment.Summary ]
+              ]
+              // Show the remarks etc.
+              match entity.Comment.Remarks with
+              | Some r -> p [ Class "fsdocs-remarks" ] [ embed r ]
+              | None -> ()
+              for note in entity.Comment.Notes do
+                  h5 [ Class "fsdocs-note-header" ] [ !! "Note" ]
 
-                    p [ Class "fsdocs-note" ] [ embed note ]
+                  p [ Class "fsdocs-note" ] [ embed note ]
 
-                for example in entity.Comment.Examples do
-                    h5 [ Class "fsdocs-example-header" ] [ !! "Example" ]
+              for example in entity.Comment.Examples do
+                  h5 [ Class "fsdocs-example-header" ] [ !! "Example" ]
 
-                    p [ Class "fsdocs-example" ] [ embed example ]
+                  p [ Class "fsdocs-example" ] [ embed example ]
 
-                ]
+          ]
 
           if (byCategory.Length > 1) then
               // If there is more than 1 category in the type, generate TOC
               h3 [] [ !! "Table of contents" ]
 
-              ul
-                  []
-                  [ for (index, _, name) in byCategory do
-                        li [] [ a [ Href(sprintf "#section%d" index) ] [ !!name ] ] ]
+              ul [] [
+                  for (index, _, name) in byCategory do
+                      li [] [ a [ Href(sprintf "#section%d" index) ] [ !!name ] ]
+              ]
 
           //<!-- Render nested types and modules, if there are any -->
 
           let nestedEntities = entity.NestedEntities |> List.filter (fun e -> not e.IsObsolete)
 
           if (nestedEntities.Length > 0) then
-              div
-                  []
-                  [ h3
-                        []
-                        [ !!(if nestedEntities |> List.forall (fun e -> not e.IsTypeDefinition) then
-                                 "Nested modules"
-                             elif nestedEntities |> List.forall (fun e -> e.IsTypeDefinition) then
-                                 "Types"
-                             else
-                                 "Types and nested modules") ]
-                    yield! renderEntities nestedEntities ]
+              div [] [
+                  h3 [] [
+                      !!(if nestedEntities |> List.forall (fun e -> not e.IsTypeDefinition) then
+                             "Nested modules"
+                         elif nestedEntities |> List.forall (fun e -> e.IsTypeDefinition) then
+                             "Types"
+                         else
+                             "Types and nested modules")
+                  ]
+                  yield! renderEntities nestedEntities
+              ]
 
           for (index, ms, name) in byCategory do
               // Iterate over all the categories and print members. If there are more than one
@@ -493,35 +487,35 @@ type HtmlRender(model: ApiDocModel, ?menuTemplateFolder: string) =
         [ if allByCategory.Length > 0 then
               h2 [ Id ns.UrlHash ] [ !!(ns.Name + " Namespace") ]
 
-              div
-                  [ Class "fsdocs-xmldoc" ]
-                  [ match ns.NamespaceDocs with
-                    | Some nsdocs ->
-                        p [] [ embed nsdocs.Summary ]
+              div [ Class "fsdocs-xmldoc" ] [
+                  match ns.NamespaceDocs with
+                  | Some nsdocs ->
+                      p [] [ embed nsdocs.Summary ]
 
-                        match nsdocs.Remarks with
-                        | Some r -> p [] [ embed r ]
-                        | None -> ()
+                      match nsdocs.Remarks with
+                      | Some r -> p [] [ embed r ]
+                      | None -> ()
 
-                    | None -> () ]
+                  | None -> ()
+              ]
 
               if (allByCategory.Length > 1) then
                   h3 [] [ !! "Contents" ]
 
-                  ul
-                      []
-                      [ for category in allByCategory do
-                            li [] [ a [ Href("#category-" + category.CategoryIndex) ] [ !!category.CategoryName ] ] ]
+                  ul [] [
+                      for category in allByCategory do
+                          li [] [ a [ Href("#category-" + category.CategoryIndex) ] [ !!category.CategoryName ] ]
+                  ]
 
               for category in allByCategory do
                   if (allByCategory.Length > 1) then
-                      h3
-                          []
-                          [ a
-                                [ Class "anchor"
-                                  Name("category-" + category.CategoryIndex)
-                                  Href("#category-" + category.CategoryIndex) ]
-                                [ !!category.CategoryName ] ]
+                      h3 [] [
+                          a [
+                              Class "anchor"
+                              Name("category-" + category.CategoryIndex)
+                              Href("#category-" + category.CategoryIndex)
+                          ] [ !!category.CategoryName ]
+                      ]
 
                   yield! renderEntities category.CategoryEntites ]
 
@@ -531,16 +525,14 @@ type HtmlRender(model: ApiDocModel, ?menuTemplateFolder: string) =
           for _allByCategory, ns in categorise do
 
               // Generate the entry for the namespace
-              tr
-                  []
-                  [ td
-                        []
-                        [ a [ Href(ns.Url(root, collectionName, qualify, model.FileExtensions.InUrl)) ] [ !!ns.Name ] ]
-                    td
-                        []
-                        [ match ns.NamespaceDocs with
-                          | Some nsdocs -> embed nsdocs.Summary
-                          | None -> () ] ] ]
+              tr [] [
+                  td [] [ a [ Href(ns.Url(root, collectionName, qualify, model.FileExtensions.InUrl)) ] [ !!ns.Name ] ]
+                  td [] [
+                      match ns.NamespaceDocs with
+                      | Some nsdocs -> embed nsdocs.Summary
+                      | None -> ()
+                  ]
+              ] ]
 
     let listOfNamespacesNavAux otherDocs (nsOpt: ApiDocNamespace option) =
         [
@@ -550,12 +542,12 @@ type HtmlRender(model: ApiDocModel, ?menuTemplateFolder: string) =
           if otherDocs && model.Collection.CollectionName <> "FSharp.Core" then
               li [ Class "nav-header" ] [ !! "API Reference" ]
 
-              li
-                  [ Class "nav-item" ]
-                  [ a
-                        [ Class "nav-link"
-                          Href(model.IndexFileUrl(root, collectionName, qualify, model.FileExtensions.InUrl)) ]
-                        [ !! "All Namespaces" ] ]
+              li [ Class "nav-item" ] [
+                  a [
+                      Class "nav-link"
+                      Href(model.IndexFileUrl(root, collectionName, qualify, model.FileExtensions.InUrl))
+                  ] [ !! "All Namespaces" ]
+              ]
           else
 
               let categorise = Categorise.model model
@@ -568,45 +560,46 @@ type HtmlRender(model: ApiDocModel, ?menuTemplateFolder: string) =
               for allByCategory, ns in categorise do
 
                   // Generate the entry for the namespace
-                  li
-                      [ Class(
-                            "nav-item"
-                            +
-                            // add the 'active' class if this is the namespace of the thing being shown
-                            match nsOpt with
-                            | Some ns2 when ns.Name = ns2.Name -> " active"
-                            | _ -> ""
-                        ) ]
-                      [ span
-                            []
-                            [ a
-                                  [ Class(
-                                        "nav-link"
-                                        +
-                                        // add the 'active' class if this is the namespace of the thing being shown
-                                        match nsOpt with
-                                        | Some ns2 when ns.Name = ns2.Name -> " active"
-                                        | _ -> ""
-                                    )
-                                    Href(ns.Url(root, collectionName, qualify, model.FileExtensions.InUrl)) ]
-                                  [ !!ns.Name ]
+                  li [
+                      Class(
+                          "nav-item"
+                          +
+                          // add the 'active' class if this is the namespace of the thing being shown
+                          match nsOpt with
+                          | Some ns2 when ns.Name = ns2.Name -> " active"
+                          | _ -> ""
+                      )
+                  ] [
+                      span [] [
+                          a [
+                              Class(
+                                  "nav-link"
+                                  +
+                                  // add the 'active' class if this is the namespace of the thing being shown
+                                  match nsOpt with
+                                  | Some ns2 when ns.Name = ns2.Name -> " active"
+                                  | _ -> ""
+                              )
+                              Href(ns.Url(root, collectionName, qualify, model.FileExtensions.InUrl))
+                          ] [ !!ns.Name ]
 
-                              ] ]
+                      ]
+                  ]
 
                   // In the navigation bar generate the expanded list of entities
                   // for the active namespace
                   match nsOpt with
                   | Some ns2 when ns.Name = ns2.Name ->
-                      ul
-                          [ Custom("list-style-type", "none") (* Class "navbar-nav " *) ]
-                          [ for category in allByCategory do
-                                for e in category.CategoryEntites do
-                                    li
-                                        [ Class "nav-item" ]
-                                        [ a
-                                              [ Class "nav-link"
-                                                Href(e.Url(root, collectionName, qualify, model.FileExtensions.InUrl)) ]
-                                              [ !!e.Name ] ] ]
+                      ul [ Custom("list-style-type", "none") (* Class "navbar-nav " *) ] [
+                          for category in allByCategory do
+                              for e in category.CategoryEntites do
+                                  li [ Class "nav-item" ] [
+                                      a [
+                                          Class "nav-link"
+                                          Href(e.Url(root, collectionName, qualify, model.FileExtensions.InUrl))
+                                      ] [ !!e.Name ]
+                                  ]
+                      ]
                   | _ -> () ]
 
     let listOfNamespacesNav otherDocs (nsOpt: ApiDocNamespace option) =
@@ -666,19 +659,19 @@ type HtmlRender(model: ApiDocModel, ?menuTemplateFolder: string) =
         let collection = model.Collection
 
         (let content =
-            div
-                []
-                [ h1 [] [ !! "API Reference" ]
-                  h2 [] [ !! "Available Namespaces:" ]
-                  table
-                      [ Class "table outer-list fsdocs-member-list" ]
-                      [ thead
-                            []
-                            [ tr
-                                  []
-                                  [ td [ Class "fsdocs-member-list-header" ] [ !! "Namespace" ]
-                                    td [ Class "fsdocs-member-list-header" ] [ !! "Description" ] ] ]
-                        tbody [] (tableOfNamespacesAux ()) ] ]
+            div [] [
+                h1 [] [ !! "API Reference" ]
+                h2 [] [ !! "Available Namespaces:" ]
+                table [ Class "table outer-list fsdocs-member-list" ] [
+                    thead [] [
+                        tr [] [
+                            td [ Class "fsdocs-member-list-header" ] [ !! "Namespace" ]
+                            td [ Class "fsdocs-member-list-header" ] [ !! "Description" ]
+                        ]
+                    ]
+                    tbody [] (tableOfNamespacesAux ())
+                ]
+            ]
 
          let pageTitle = sprintf "%s (API Reference)" collectionName
 

--- a/src/FSharp.Formatting.ApiDocs/GenerateHtml.fs
+++ b/src/FSharp.Formatting.ApiDocs/GenerateHtml.fs
@@ -180,99 +180,99 @@ type HtmlRender(model: ApiDocModel, ?menuTemplateFolder: string) =
                                   ]
                               ]
 
-                              td [ Class "fsdocs-member-xmldoc" ] [
-                                  details [] [
-                                      summary [] [
-                                          div [ Class "fsdocs-summary" ] [
-                                              yield! copyXmlSigIconForSymbolMarkdown m.Symbol
-                                              yield! copyXmlSigIconForSymbol m.Symbol
-                                              yield! sourceLink m.SourceLocation
-                                              p [ Class "fsdocs-summary" ] [ embed m.Comment.Summary ]
-                                          ]
-                                      ]
-
-                                      match m.Comment.Remarks with
-                                      | Some r -> p [ Class "fsdocs-remarks" ] [ embed r ]
-                                      | None -> ()
-
-                                      match m.ExtendedType with
-                                      | Some(_, extendedTypeHtml) ->
-                                          p [] [ !! "Extended Type: "; embed extendedTypeHtml ]
-                                      | _ -> ()
-
-                                      if not m.Parameters.IsEmpty then
-                                          dl [ Class "fsdocs-params" ] [
-                                              for parameter in m.Parameters do
-                                                  dt [ Class "fsdocs-param" ] [
-                                                      span [ Class "fsdocs-param-name" ] [
-                                                          !!parameter.ParameterNameText
-                                                      ]
-                                                      !! ":"
-                                                      embed parameter.ParameterType
-                                                  ]
-
-                                                  dd [ Class "fsdocs-param-docs" ] [
-                                                      match parameter.ParameterDocs with
-                                                      | None -> ()
-                                                      | Some d -> p [] [ embed d ]
-                                                  ]
-                                          ]
-
-                                      match m.ReturnInfo.ReturnType with
-                                      | None -> ()
-                                      | Some(_, returnTypeHtml) ->
-                                          dl [ Class "fsdocs-returns" ] [
-                                              dt [] [
-                                                  span [ Class "fsdocs-return-name" ] [
-                                                      !!(if m.Kind <> ApiDocMemberKind.RecordField then
-                                                             "Returns: "
-                                                         else
-                                                             "Field type: ")
-                                                  ]
-                                                  embed returnTypeHtml
-                                              ]
-                                              dd [ Class "fsdocs-return-docs" ] [
-                                                  match m.ReturnInfo.ReturnDocs with
-                                                  | None -> ()
-                                                  | Some r -> p [] [ embed r ]
-                                              ]
-                                          ]
-
-                                      if not m.Comment.Exceptions.IsEmpty then
-                                          //p [] [ !! "Exceptions:" ]
-                                          table [ Class "fsdocs-exception-list" ] [
-                                              for (nm, link, html) in m.Comment.Exceptions do
-                                                  tr [] [
-                                                      td
-                                                          []
-                                                          (match link with
-                                                           | None -> []
-                                                           | Some href -> [ a [ Href href ] [ !!nm ] ])
-                                                      td [] [ embed html ]
-                                                  ]
-                                          ]
-
-                                      for e in m.Comment.Notes do
-                                          h5 [ Class "fsdocs-note-header" ] [ !! "Note" ]
-
-                                          p [ Class "fsdocs-note" ] [ embed e ]
-
-                                      for e in m.Comment.Examples do
-                                          h5 [ Class "fsdocs-example-header" ] [ !! "Example" ]
-
-                                          p [
-                                              Class "fsdocs-example"
-                                              if e.Id.IsSome then
-                                                  Id e.Id.Value
-                                          ] [ embed e ]
-
-                                  //if m.IsObsolete then
-                                  //    obsoleteMessage m.ObsoleteMessage
-
-                                  //if not (String.IsNullOrEmpty(m.Details.FormatCompiledName)) then
-                                  //    p [] [!!"CompiledName: "; code [] [!!m.Details.FormatCompiledName]]
+                              let smry =
+                                  div [ Class "fsdocs-summary" ] [
+                                      yield! copyXmlSigIconForSymbolMarkdown m.Symbol
+                                      yield! copyXmlSigIconForSymbol m.Symbol
+                                      yield! sourceLink m.SourceLocation
+                                      p [ Class "fsdocs-summary" ] [ embed m.Comment.Summary ]
                                   ]
-                              ]
+
+                              let dtls =
+                                  [ match m.Comment.Remarks with
+                                    | Some r -> p [ Class "fsdocs-remarks" ] [ embed r ]
+                                    | None -> ()
+
+                                    match m.ExtendedType with
+                                    | Some(_, extendedTypeHtml) -> p [] [ !! "Extended Type: "; embed extendedTypeHtml ]
+                                    | _ -> ()
+
+                                    if not m.Parameters.IsEmpty then
+                                        dl [ Class "fsdocs-params" ] [
+                                            for parameter in m.Parameters do
+                                                dt [ Class "fsdocs-param" ] [
+                                                    span [ Class "fsdocs-param-name" ] [ !!parameter.ParameterNameText ]
+                                                    !! ":"
+                                                    embed parameter.ParameterType
+                                                ]
+
+                                                dd [ Class "fsdocs-param-docs" ] [
+                                                    match parameter.ParameterDocs with
+                                                    | None -> ()
+                                                    | Some d -> p [] [ embed d ]
+                                                ]
+                                        ]
+
+                                    match m.ReturnInfo.ReturnType with
+                                    | None -> ()
+                                    | Some(_, returnTypeHtml) ->
+                                        dl [ Class "fsdocs-returns" ] [
+                                            dt [] [
+                                                span [ Class "fsdocs-return-name" ] [
+                                                    !!(if m.Kind <> ApiDocMemberKind.RecordField then
+                                                           "Returns: "
+                                                       else
+                                                           "Field type: ")
+                                                ]
+                                                embed returnTypeHtml
+                                            ]
+                                            dd [ Class "fsdocs-return-docs" ] [
+                                                match m.ReturnInfo.ReturnDocs with
+                                                | None -> ()
+                                                | Some r -> p [] [ embed r ]
+                                            ]
+                                        ]
+
+                                    if not m.Comment.Exceptions.IsEmpty then
+                                        //p [] [ !! "Exceptions:" ]
+                                        table [ Class "fsdocs-exception-list" ] [
+                                            for (nm, link, html) in m.Comment.Exceptions do
+                                                tr [] [
+                                                    td
+                                                        []
+                                                        (match link with
+                                                         | None -> []
+                                                         | Some href -> [ a [ Href href ] [ !!nm ] ])
+                                                    td [] [ embed html ]
+                                                ]
+                                        ]
+
+                                    for e in m.Comment.Notes do
+                                        h5 [ Class "fsdocs-note-header" ] [ !! "Note" ]
+
+                                        p [ Class "fsdocs-note" ] [ embed e ]
+
+                                    for e in m.Comment.Examples do
+                                        h5 [ Class "fsdocs-example-header" ] [ !! "Example" ]
+
+                                        p [
+                                            Class "fsdocs-example"
+                                            if e.Id.IsSome then
+                                                Id e.Id.Value
+                                        ] [ embed e ]
+                                    //if m.IsObsolete then
+                                    //    obsoleteMessage m.ObsoleteMessage
+
+                                    //if not (String.IsNullOrEmpty(m.Details.FormatCompiledName)) then
+                                    //    p [] [!!"CompiledName: "; code [] [!!m.Details.FormatCompiledName]]
+                                    ]
+
+                              td
+                                  [ Class "fsdocs-member-xmldoc" ]
+                                  (match dtls, m.Comment.Summary.HtmlText.Trim() with
+                                   | [], _ -> [ smry ]
+                                   | _, "" -> dtls
+                                   | _, _ -> [ details [] ((summary [] [ smry ]) :: dtls) ])
                           ]
                   ]
               ] ]


### PR DESCRIPTION
Fixes #778 by using a `<details>` html tag for API docs member info. Below is a gif showing how it looks in fsharp-core-docs.

![collapsible-docs](https://user-images.githubusercontent.com/5226115/231496959-edb2f9c2-7f33-4b37-a51a-e71807facbad.gif)
