### PR TITLE
Update Dockerfile

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,85 +1,29 @@
-FROM jupyter/base-notebook:latest
+FROM mcr.microsoft.com/dotnet/sdk:7.0
 
-# Install .NET CLI dependencies
+RUN apt-get update \
+    && apt-get -y upgrade \
+    && apt-get -y install python3 python3-pip python3-dev ipython3
 
-ARG NB_USER=fsdocs-user
+RUN python3 -m pip install --no-cache-dir notebook jupyterlab
+
+ARG NB_USER=jovyan
 ARG NB_UID=1000
 ENV USER ${NB_USER}
 ENV NB_UID ${NB_UID}
 ENV HOME /home/${NB_USER}
 
-WORKDIR ${HOME}
+RUN adduser --disabled-password \
+    --gecos "Default user" \
+    --uid ${NB_UID} \
+    ${NB_USER}
 
+COPY . ${HOME}
 USER root
-RUN apt-get update
-RUN apt-get install -y curl
-
-ENV \
-    # Enable detection of running in a container
-    DOTNET_RUNNING_IN_CONTAINER=true \
-    # Enable correct mode for dotnet watch (only mode supported in a container)
-    DOTNET_USE_POLLING_FILE_WATCHER=true \
-    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
-    NUGET_XMLDOC_MODE=skip \
-    # Opt out of telemetry until after we install jupyter when building the image, this prevents caching of machine id
-    DOTNET_INTERACTIVE_CLI_TELEMETRY_OPTOUT=true
-
-# Install .NET CLI dependencies
-RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        libc6 \
-        libgcc1 \
-        libgssapi-krb5-2 \
-        libicu66 \
-        libssl1.1 \
-        libstdc++6 \
-        zlib1g \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install .NET Core SDK
-
-# When updating the SDK version, the sha512 value a few lines down must also be updated.
-ENV DOTNET_SDK_VERSION 5.0.101
-
-RUN dotnet_sdk_version=5.0.101 \
-    && curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$dotnet_sdk_version/dotnet-sdk-$dotnet_sdk_version-linux-x64.tar.gz \
-    && dotnet_sha512='398d88099d765b8f5b920a3a2607c2d2d8a946786c1a3e51e73af1e663f0ee770b2b624a630b1bec1ceed43628ea8bc97963ba6c870d42bec064bde1cd1c9edb' \
-    && echo "$dotnet_sha512 dotnet.tar.gz" | sha512sum -c - \
-    && mkdir -p /usr/share/dotnet \
-    && tar -ozxf dotnet.tar.gz -C /usr/share/dotnet \
-    && rm dotnet.tar.gz \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
-    # Trigger first run experience by running arbitrary cmd
-    && dotnet help
-
-# Copy notebooks
-
-COPY ./ ${HOME}/notebooks/
-
-# Copy package sources
-
-COPY ./NuGet.config ${HOME}/nuget.config
-
 RUN chown -R ${NB_UID} ${HOME}
-USER ${USER}
+USER ${NB_USER}
 
-#Install nteract 
-RUN pip install nteract_on_jupyter
+ENV PATH="${PATH}:$HOME/.dotnet/tools/"
 
-# Install lastest build from master branch of Microsoft.DotNet.Interactive
-RUN dotnet tool install -g Microsoft.dotnet-interactive --add-source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json"
+RUN dotnet tool install --global Microsoft.dotnet-interactive --version 1.0.410202
 
-#latest stable from nuget.org
-#RUN dotnet tool install -g Microsoft.dotnet-interactive --add-source "https://api.nuget.org/v3/index.json"
-
-ENV PATH="${PATH}:${HOME}/.dotnet/tools"
-RUN echo "$PATH"
-
-# Install kernel specs
-RUN dotnet interactive jupyter install
-
-# Enable telemetry once we install jupyter for the image
-ENV DOTNET_INTERACTIVE_CLI_TELEMETRY_OPTOUT=false
-
-# Set root to notebooks
-WORKDIR ${HOME}/notebooks/
+RUN dotnet-interactive jupyter install


### PR DESCRIPTION
This PR updates the Dockerfile used for binder. 

I cannot think of any real way to test this, as a full repo with gh pages would have to be set up with this. 

However, Plotly.NET uses this dockerfile, and you can see in the docs pages that you can open and execute the notebooks on binder. See for example: https://plotly.net/distribution-charts/violin-plots.html (click on 'run in binder')

closes #827 