### PR TITLE
Add previous and next page url substitutions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ tests/FSharp.Literate.Tests/output1/
 .vscode/
 .DS_Store
 tests/FSharp.Literate.Tests/output2/
+tests/FSharp.Literate.Tests/previous-next-output/

--- a/docs/content.fsx
+++ b/docs/content.fsx
@@ -146,6 +146,8 @@ See [Styling](styling.html) for information about template parameters and stylin
 | `fsdocs-source-basename`      | Name of original input source, excluding its extensions, relative to the `docs` root  |
 | `fsdocs-tooltips`             | Generated hidden div elements for tooltips                    |
 | `fsdocs-watch-script`         | The websocket script used in watch mode to trigger hot reload |
+| `fsdocs-previous-page-link`   | A relative link to the previous page based on the frontmatter index data |
+| `fsdocs-next-page-link`       | A relative link to the next page based on the frontmatter index data |
 
 The following substitutions are extracted from your project files and may or may not be used by the default
 template:

--- a/src/FSharp.Formatting.Literate/Contexts.fs
+++ b/src/FSharp.Formatting.Literate/Contexts.fs
@@ -63,10 +63,10 @@ type internal LiterateDocModel =
         Category: string option
 
         /// The category index in the front matter (determines the order of categories)
-        CategoryIndex: string option
+        CategoryIndex: int option
 
         /// The index in the front matter (Determines the order of files within a category)
-        Index: string option
+        Index: int option
 
         /// The relative output path
         OutputPath: string

--- a/src/FSharp.Formatting.Literate/Literate.fs
+++ b/src/FSharp.Formatting.Literate/Literate.fs
@@ -5,7 +5,6 @@ open System.Collections.Generic
 open System.IO
 open System.Runtime.CompilerServices
 open FSharp.Formatting.Markdown
-open FSharp.Formatting.CodeFormat
 open FSharp.Formatting.Templating
 
 /// <summary>
@@ -260,7 +259,7 @@ type Literate private () =
         let doc =
             MarkdownDocument(doc.Paragraphs @ [ InlineHtmlBlock(doc.FormattedTips, None, None) ], doc.DefinedLinks)
 
-        let sb = new System.Text.StringBuilder()
+        let sb = System.Text.StringBuilder()
         use wr = new StringWriter(sb)
 
         HtmlFormatting.formatAsHtml
@@ -424,7 +423,8 @@ type Literate private () =
             crefResolver,
             mdlinkResolver,
             parseOptions,
-            onError
+            onError,
+            filesWithFrontMatter: FrontMatterFile array
         ) =
 
         let parseOptions =
@@ -457,7 +457,7 @@ type Literate private () =
                 None
 
         let doc = downloadImagesForDoc imageSaver doc
-        let docModel = Formatting.transformDocument doc output ctx
+        let docModel = Formatting.transformDocument filesWithFrontMatter doc output ctx
         docModel
 
     /// Parse and transform an F# script file
@@ -477,7 +477,8 @@ type Literate private () =
             rootInputFolder,
             crefResolver,
             mdlinkResolver,
-            onError
+            onError,
+            filesWithFrontMatter: FrontMatterFile array
         ) =
 
         let parseOptions =
@@ -509,7 +510,7 @@ type Literate private () =
                 None
 
         let doc = downloadImagesForDoc imageSaver doc
-        let docModel = Formatting.transformDocument doc output ctx
+        let docModel = Formatting.transformDocument filesWithFrontMatter doc output ctx
         docModel
 
     /// Convert a markdown file into HTML or another output kind
@@ -529,7 +530,8 @@ type Literate private () =
             ?rootInputFolder,
             ?crefResolver,
             ?mdlinkResolver,
-            ?onError
+            ?onError,
+            ?filesWithFrontMatter
         ) =
 
         let outputKind = defaultArg outputKind OutputKind.Html
@@ -537,6 +539,7 @@ type Literate private () =
         let crefResolver = defaultArg crefResolver (fun _ -> None)
         let mdlinkResolver = defaultArg mdlinkResolver (fun _ -> None)
         let substitutions = defaultArg substitutions []
+        let filesWithFrontMatter = defaultArg filesWithFrontMatter Array.empty
 
         let res =
             Literate.ParseAndTransformMarkdownFile(
@@ -554,7 +557,8 @@ type Literate private () =
                 crefResolver = crefResolver,
                 mdlinkResolver = mdlinkResolver,
                 parseOptions = MarkdownParseOptions.AllowYamlFrontMatter,
-                onError = onError
+                onError = onError,
+                filesWithFrontMatter = filesWithFrontMatter
             )
 
         SimpleTemplating.UseFileAsSimpleTemplate(res.Substitutions, template, output)
@@ -582,7 +586,8 @@ type Literate private () =
             ?rootInputFolder,
             ?crefResolver,
             ?mdlinkResolver,
-            ?onError
+            ?onError,
+            ?filesWithFrontMatter
         ) =
 
         let outputKind = defaultArg outputKind OutputKind.Html
@@ -590,6 +595,7 @@ type Literate private () =
         let crefResolver = defaultArg crefResolver (fun _ -> None)
         let mdlinkResolver = defaultArg mdlinkResolver (fun _ -> None)
         let substitutions = defaultArg substitutions []
+        let filesWithFrontMatter = defaultArg filesWithFrontMatter Array.empty
 
         let res =
             Literate.ParseAndTransformScriptFile(
@@ -607,7 +613,8 @@ type Literate private () =
                 rootInputFolder = rootInputFolder,
                 crefResolver = crefResolver,
                 mdlinkResolver = mdlinkResolver,
-                onError = onError
+                onError = onError,
+                filesWithFrontMatter = filesWithFrontMatter
             )
 
         SimpleTemplating.UseFileAsSimpleTemplate(res.Substitutions, template, output)

--- a/src/fsdocs-tool/BuildCommand.fs
+++ b/src/fsdocs-tool/BuildCommand.fs
@@ -173,6 +173,7 @@ type internal DocContent
         outputFolderRelativeToRoot
         imageSaver
         mdlinkResolver
+        (filesWithFrontMatter: FrontMatterFile array)
         =
         [ let name = Path.GetFileName(inputFileFullPath)
 
@@ -276,7 +277,8 @@ type internal DocContent
                                   rootInputFolder = rootInputFolder,
                                   crefResolver = crefResolver,
                                   mdlinkResolver = mdlinkResolver,
-                                  onError = Some onError
+                                  onError = Some onError,
+                                  filesWithFrontMatter = filesWithFrontMatter
                               )
 
                           yield
@@ -313,7 +315,8 @@ type internal DocContent
                                   crefResolver = crefResolver,
                                   mdlinkResolver = mdlinkResolver,
                                   parseOptions = MarkdownParseOptions.AllowYamlFrontMatter,
-                                  onError = Some onError
+                                  onError = Some onError,
+                                  filesWithFrontMatter = filesWithFrontMatter
                               )
 
                           yield
@@ -353,6 +356,7 @@ type internal DocContent
         (htmlTemplate, texTemplate, pynbTemplate, fsxTemplate, mdTemplate, isOtherLang, rootInputFolder, fullPathFileMap)
         (inputFolderAsGiven: string)
         outputFolderRelativeToRoot
+        (filesWithFrontMatter: FrontMatterFile array)
         =
         [
           // Look for the presence of the _template.* files to activate the
@@ -426,6 +430,7 @@ type internal DocContent
                           fullPathFileMap,
                           OutputKind.Html
                       ))
+                      filesWithFrontMatter
 
               yield!
                   processFile
@@ -442,6 +447,7 @@ type internal DocContent
                           fullPathFileMap,
                           OutputKind.Latex
                       ))
+                      filesWithFrontMatter
 
               yield!
                   processFile
@@ -458,6 +464,7 @@ type internal DocContent
                           fullPathFileMap,
                           OutputKind.Pynb
                       ))
+                      filesWithFrontMatter
 
               yield!
                   processFile
@@ -474,6 +481,7 @@ type internal DocContent
                           fullPathFileMap,
                           OutputKind.Fsx
                       ))
+                      filesWithFrontMatter
 
               yield!
                   processFile
@@ -490,6 +498,7 @@ type internal DocContent
                           fullPathFileMap,
                           OutputKind.Markdown
                       ))
+                      filesWithFrontMatter
 
           for subInputFolderFullPath in Directory.EnumerateDirectories(inputFolderAsGiven) do
               let subInputFolderName = Path.GetFileName(subInputFolderFullPath)
@@ -511,7 +520,8 @@ type internal DocContent
                            rootInputFolder,
                            fullPathFileMap)
                           (Path.Combine(inputFolderAsGiven, subInputFolderName))
-                          (Path.Combine(outputFolderRelativeToRoot, subInputFolderName)) ]
+                          (Path.Combine(outputFolderRelativeToRoot, subInputFolderName))
+                          filesWithFrontMatter ]
 
     member _.Convert(rootInputFolderAsGiven, htmlTemplate, extraInputs) =
 
@@ -523,12 +533,32 @@ type internal DocContent
                   yield! prepFolder rootInputFolderAsGiven outputFolderRelativeToRoot ]
             |> Map.ofList
 
+        // In order to create {{next-page-url}} and {{previous-page-url}}
+        // We need to scan all *.fsx and *.md files for their frontmatter.
+        let filesWithFrontMatter =
+            fullPathFileMap
+            |> Map.keys
+            |> Seq.map fst
+            |> Seq.distinct
+            |> Seq.choose (fun fileName ->
+                let ext = Path.GetExtension fileName
+
+                if ext = ".fsx" then
+                    ParseScript.ParseFrontMatter(fileName)
+                elif ext = ".md" then
+                    File.ReadLines fileName |> FrontMatterFile.ParseFromLines fileName
+                else
+                    None)
+            |> Seq.sortBy (fun { Index = idx; CategoryIndex = cIdx } -> cIdx, idx)
+            |> Seq.toArray
+
         [ for (rootInputFolderAsGiven, outputFolderRelativeToRoot) in inputDirectories do
               yield!
                   processFolder
                       (htmlTemplate, None, None, None, None, false, Some rootInputFolderAsGiven, fullPathFileMap)
                       rootInputFolderAsGiven
-                      outputFolderRelativeToRoot ]
+                      outputFolderRelativeToRoot
+                      filesWithFrontMatter ]
 
     member _.GetSearchIndexEntries(docModels: (string * bool * LiterateDocModel) list) =
         [| for (_inputFile, isOtherLang, model) in docModels do
@@ -564,7 +594,7 @@ type internal DocContent
                          Int32.MaxValue)
                 | None -> Int32.MaxValue)
 
-        let orderList list =
+        let orderList (list: LiterateDocModel list) =
             list
             |> List.sortBy (fun model ->
                 match model.Index with

--- a/src/fsdocs-tool/packages.lock.json
+++ b/src/fsdocs-tool/packages.lock.json
@@ -42,6 +42,32 @@
           "FSharp.Core": "0.0.0"
         }
       },
+      "Microsoft.Build": {
+        "type": "Transitive",
+        "resolved": "17.2.0",
+        "contentHash": "Rpf+7b8WHcgkrEQnGcV8FiAIl15ZC7Oit4t213fMoRdJb8SUYKdB71ZzWFaV5f9glN3y+R4cxRDY0dkwaIpwYw==",
+        "dependencies": {
+          "Microsoft.Build.Framework": "17.2.0",
+          "Microsoft.NET.StringTools": "1.0.0",
+          "Microsoft.Win32.Registry": "4.3.0",
+          "System.Collections.Immutable": "5.0.0",
+          "System.Configuration.ConfigurationManager": "4.7.0",
+          "System.Reflection.Metadata": "1.6.0",
+          "System.Security.Principal.Windows": "4.7.0",
+          "System.Text.Encoding.CodePages": "4.0.1",
+          "System.Text.Json": "6.0.0",
+          "System.Threading.Tasks.Dataflow": "6.0.0"
+        }
+      },
+      "Microsoft.Build.Framework": {
+        "type": "Transitive",
+        "resolved": "17.2.0",
+        "contentHash": "5MtMF6vZeK8Nq6r9GctGpfiBa+r5+pTCnZJp8Bi6C74TysWl5ri6vmuLbsYhzvXqTPbnvDxCpKAI90z3m4m5mw==",
+        "dependencies": {
+          "Microsoft.Win32.Registry": "4.3.0",
+          "System.Security.Permissions": "4.7.0"
+        }
+      },
       "Microsoft.NET.StringTools": {
         "type": "Transitive",
         "resolved": "1.0.0",
@@ -417,34 +443,6 @@
           "System.Reflection.Emit": "4.7.0",
           "System.Reflection.Metadata": "7.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
-        }
-      },
-      "Microsoft.Build": {
-        "type": "CentralTransitive",
-        "requested": "(, )",
-        "resolved": "17.2.0",
-        "contentHash": "Rpf+7b8WHcgkrEQnGcV8FiAIl15ZC7Oit4t213fMoRdJb8SUYKdB71ZzWFaV5f9glN3y+R4cxRDY0dkwaIpwYw==",
-        "dependencies": {
-          "Microsoft.Build.Framework": "17.2.0",
-          "Microsoft.NET.StringTools": "1.0.0",
-          "Microsoft.Win32.Registry": "4.3.0",
-          "System.Collections.Immutable": "5.0.0",
-          "System.Configuration.ConfigurationManager": "4.7.0",
-          "System.Reflection.Metadata": "1.6.0",
-          "System.Security.Principal.Windows": "4.7.0",
-          "System.Text.Encoding.CodePages": "4.0.1",
-          "System.Text.Json": "6.0.0",
-          "System.Threading.Tasks.Dataflow": "6.0.0"
-        }
-      },
-      "Microsoft.Build.Framework": {
-        "type": "CentralTransitive",
-        "requested": "(, )",
-        "resolved": "17.2.0",
-        "contentHash": "5MtMF6vZeK8Nq6r9GctGpfiBa+r5+pTCnZJp8Bi6C74TysWl5ri6vmuLbsYhzvXqTPbnvDxCpKAI90z3m4m5mw==",
-        "dependencies": {
-          "Microsoft.Win32.Registry": "4.3.0",
-          "System.Security.Permissions": "4.7.0"
         }
       },
       "System.Memory": {

--- a/tests/FSharp.Literate.Tests/packages.lock.json
+++ b/tests/FSharp.Literate.Tests/packages.lock.json
@@ -59,6 +59,32 @@
         "resolved": "4.5.0",
         "contentHash": "s8JpqTe9bI2f49Pfr3dFRfoVSuFQyraTj68c3XXjIS/MRGvvkLnrg6RLqnTjdShX+AdFUCCU/4Xex58AdUfs6A=="
       },
+      "Microsoft.Build": {
+        "type": "Transitive",
+        "resolved": "17.2.0",
+        "contentHash": "Rpf+7b8WHcgkrEQnGcV8FiAIl15ZC7Oit4t213fMoRdJb8SUYKdB71ZzWFaV5f9glN3y+R4cxRDY0dkwaIpwYw==",
+        "dependencies": {
+          "Microsoft.Build.Framework": "17.2.0",
+          "Microsoft.NET.StringTools": "1.0.0",
+          "Microsoft.Win32.Registry": "4.3.0",
+          "System.Collections.Immutable": "5.0.0",
+          "System.Configuration.ConfigurationManager": "4.7.0",
+          "System.Reflection.Metadata": "1.6.0",
+          "System.Security.Principal.Windows": "4.7.0",
+          "System.Text.Encoding.CodePages": "4.0.1",
+          "System.Text.Json": "6.0.0",
+          "System.Threading.Tasks.Dataflow": "6.0.0"
+        }
+      },
+      "Microsoft.Build.Framework": {
+        "type": "Transitive",
+        "resolved": "17.2.0",
+        "contentHash": "5MtMF6vZeK8Nq6r9GctGpfiBa+r5+pTCnZJp8Bi6C74TysWl5ri6vmuLbsYhzvXqTPbnvDxCpKAI90z3m4m5mw==",
+        "dependencies": {
+          "Microsoft.Win32.Registry": "4.3.0",
+          "System.Security.Permissions": "4.7.0"
+        }
+      },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
         "resolved": "17.7.2",
@@ -497,34 +523,6 @@
         "requested": "[0.62.0, )",
         "resolved": "0.62.0",
         "contentHash": "gKFts9WmiK4x7FCBPMesLXMkVUXTs9tL3VRY4nHNhabIa2pi7+POeXTQJ/NjjE4+ksJ8ygaUkgkPEjZ8gaoE7g=="
-      },
-      "Microsoft.Build": {
-        "type": "CentralTransitive",
-        "requested": "(, )",
-        "resolved": "17.2.0",
-        "contentHash": "Rpf+7b8WHcgkrEQnGcV8FiAIl15ZC7Oit4t213fMoRdJb8SUYKdB71ZzWFaV5f9glN3y+R4cxRDY0dkwaIpwYw==",
-        "dependencies": {
-          "Microsoft.Build.Framework": "17.2.0",
-          "Microsoft.NET.StringTools": "1.0.0",
-          "Microsoft.Win32.Registry": "4.3.0",
-          "System.Collections.Immutable": "5.0.0",
-          "System.Configuration.ConfigurationManager": "4.7.0",
-          "System.Reflection.Metadata": "1.6.0",
-          "System.Security.Principal.Windows": "4.7.0",
-          "System.Text.Encoding.CodePages": "4.0.1",
-          "System.Text.Json": "6.0.0",
-          "System.Threading.Tasks.Dataflow": "6.0.0"
-        }
-      },
-      "Microsoft.Build.Framework": {
-        "type": "CentralTransitive",
-        "requested": "(, )",
-        "resolved": "17.2.0",
-        "contentHash": "5MtMF6vZeK8Nq6r9GctGpfiBa+r5+pTCnZJp8Bi6C74TysWl5ri6vmuLbsYhzvXqTPbnvDxCpKAI90z3m4m5mw==",
-        "dependencies": {
-          "Microsoft.Win32.Registry": "4.3.0",
-          "System.Security.Permissions": "4.7.0"
-        }
       },
       "Newtonsoft.Json": {
         "type": "CentralTransitive",

--- a/tests/FSharp.Literate.Tests/previous-next/fellowship.md
+++ b/tests/FSharp.Literate.Tests/previous-next/fellowship.md
@@ -1,0 +1,9 @@
+---
+index: 1
+categoryindex: 1
+category: fiction
+---
+
+# The Fellowship of the ring
+
+[Next]({{fsdocs-next-page-link}})

--- a/tests/FSharp.Literate.Tests/previous-next/return.md
+++ b/tests/FSharp.Literate.Tests/previous-next/return.md
@@ -1,0 +1,9 @@
+---
+categoryindex: 1
+category: fiction
+index: 3
+---
+
+# The Return of the King
+
+[Previous]({{fsdocs-previous-page-link}})

--- a/tests/FSharp.Literate.Tests/previous-next/two-tower.fsx
+++ b/tests/FSharp.Literate.Tests/previous-next/two-tower.fsx
@@ -1,0 +1,13 @@
+(**
+---
+category: fiction
+index: 2
+
+categoryindex: 1
+---
+
+# The Two Towers
+
+[Previous]({{fsdocs-previous-page-link}})
+[Next]({{fsdocs-next-page-link}})
+*)


### PR DESCRIPTION
This PR introduces `{{fsdocs-previous-page-link}}` and `{{fsdocs-next-page-link}}` substitutions.
These are convenient for navigating the user to the previous or next documentation page based on the `categoryindex` and `index` frontmatter metadata.
Right now in Fantomas, we do this manually 😔. ([Sample](https://github.com/fsprojects/fantomas/blob/74b18128efc71498a4dcdbae2c3d92c8eae20e57/docs/docs/contributors/Formatted%20Code.md?plain=1#L26))
Check out the unit test to see this new feature in action.

