### PR TITLE
add minimal seo tags for open graph and twitter cards to default template

### DIFF
--- a/docs/_template.html
+++ b/docs/_template.html
@@ -7,6 +7,18 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="author" content="{{fsdocs-authors}}">
 
+    <!-- Opengraph properties (https://ogp.me/) -->
+    <meta property="og:site_name" content="{{fsdocs-collection-name"}}">
+    <meta property="og:title" content="{{fsdocs-page-title}}" />
+    <meta property="og:url" content="{{root}}{{fsdocs-source-basename}}.html">
+    <meta property="og:type" content="website" />
+
+    <!-- Twitter cards -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta property="twitter:domain" content="{{root}}{{fsdocs-source-basename}}.html">
+    <meta property="twitter:url" content="{{root}}">
+    <meta name="twitter:title" content="{{fsdocs-page-title}}">
+
     <link rel="stylesheet" id="theme_link" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.6.0/materia/bootstrap.min.css">
     <script src="https://code.jquery.com/jquery-3.4.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-Piv4xVNRyMGpqkS2by6br4gNJ7DXjqk09RmUpJ8jgGtD7zP9yug3goQfGII0yAns" crossorigin="anonymous"></script>


### PR DESCRIPTION
see #869 

This is a basic implementation using the available substitution parameters. There could be more, e.g. displaying a default image etc., but i think for that we would need additional substitutions.