### PR TITLE
Add scrollbar to long Namespace description

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+* Namespace description overflows content box. [#886](https://github.com/fsprojects/FSharp.Formatting/issues/886)
+
 ## 20.0.0-alpha-014 - 2023-11-22
 
 ### Added

--- a/docs/content/fsdocs-default.css
+++ b/docs/content/fsdocs-default.css
@@ -756,7 +756,9 @@ pre.fssnip.highlighted > code, table.pre .fssnip, table.pre .fssnip code {
 }
 
 /* Custom scrollbar styling */
-body, aside, #menu-toggle .menu, table.pre, code, .fsdocs-entity-xmldoc > div > pre, div.fsdocs-summary > pre, dialog ul, div.fsdocs-tip {
+body, aside, #menu-toggle .menu, table.pre, code, 
+.fsdocs-entity-xmldoc > div > pre, div.fsdocs-summary > pre, 
+dialog ul, div.fsdocs-tip, .fsdocs-xmldoc > pre {
     overflow-x: auto;
     max-width: 100%;
 
@@ -775,7 +777,9 @@ body, aside, #menu-toggle .menu, table.pre, code, .fsdocs-entity-xmldoc > div > 
     }
 }
 
-body, aside, #menu-toggle .menu, table.pre, code, .fsdocs-entity-xmldoc > div > pre, div.fsdocs-summary > pre, dialog ul, div.fsdocs-tip {
+body, aside, #menu-toggle .menu, table.pre, code, 
+.fsdocs-entity-xmldoc > div > pre, div.fsdocs-summary > pre, 
+dialog ul, div.fsdocs-tip, .fsdocs-xmldoc > pre {
     @media screen and (min-width: 768px) {
         &::-webkit-scrollbar {
             height: var(--spacing-200);
@@ -986,6 +990,12 @@ span[onmouseout] {
 /* API docs */
 #content > div > h2:first-child {
     margin-top: 0;
+}
+
+.fsdocs-xmldoc {
+    & pre {
+        overflow-x: auto;
+    }
 }
 
 .table {

--- a/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
+++ b/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
@@ -1849,7 +1849,10 @@ module internal SymbolReader =
     /// Wraps the summary content in a <pre> tag if it is multiline and has different column indentations.
     let readXmlElementAsSingleSummary (e: XElement) =
         let text = e.Value
-        let nonEmptyLines = e.Value.Split([| '\n' |], StringSplitOptions.RemoveEmptyEntries)
+
+        let nonEmptyLines =
+            e.Value.Split([| '\n' |], StringSplitOptions.RemoveEmptyEntries)
+            |> Array.filter (String.IsNullOrWhiteSpace >> not)
 
         if nonEmptyLines.Length = 1 then
             nonEmptyLines.[0]


### PR DESCRIPTION
Fixes https://github.com/fsprojects/FSharp.Formatting/issues/886.

There were two problems here, the [namespace XML doc](https://github.com/dotnet/fsharp/blob/54e3f09327cdddd1d83709f7a88b8c429662671d/src/FSharp.Core/prim-types.fsi#L11-L19) was wrapped in a pre tag while it shouldn't be.

And if is too long it should get the scrollbar similar to members.