### PR TITLE
Set default font-size for code.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 20.0.0-alpha-017 - 2024-01-09
+
+### Fixed
+* Set default font-size for code. [#889](https://github.com/fsprojects/FSharp.Formatting/issues/889)
+
 ## 20.0.0-alpha-016 - 2023-12-07
 
 ### Fixed

--- a/docs/content/fsdocs-default.css
+++ b/docs/content/fsdocs-default.css
@@ -721,6 +721,7 @@ code, table.pre, pre {
     color: var(--code-color);
     font-family: var(--monospace-font);
     font-variant-ligatures: none;
+    font-size: var(--font-200);
 }
 
 table.pre, #content > pre.fssnip {


### PR DESCRIPTION
I think this will improve https://github.com/fsprojects/FSharp.Formatting/issues/889.