### PR TITLE
Add -webkit-text-size-adjust to code block

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 20.0.0-alpha-018 - 2024-01-10
+
+### Fixed
+* Add -webkit-text-size-adjust. [#889](https://github.com/fsprojects/FSharp.Formatting/issues/889)
+
 ## 20.0.0-alpha-017 - 2024-01-09
 
 ### Fixed

--- a/docs/content/fsdocs-default.css
+++ b/docs/content/fsdocs-default.css
@@ -722,6 +722,7 @@ code, table.pre, pre {
     font-family: var(--monospace-font);
     font-variant-ligatures: none;
     font-size: var(--font-200);
+    -webkit-text-size-adjust: 100%;
 }
 
 table.pre, #content > pre.fssnip {


### PR DESCRIPTION
Another attempt to related https://github.com/fsprojects/FSharp.Formatting/issues/889, based on https://stackoverflow.com/questions/3226001/some-font-sizes-rendered-larger-on-safari-iphone