### PR TITLE
Avoid theme flicker in dark mode.

### DIFF
--- a/FSharp.Formatting.sln
+++ b/FSharp.Formatting.sln
@@ -125,6 +125,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "content", "content", "{FAD5
 		docs\content\fsdocs-search.js = docs\content\fsdocs-search.js
 		docs\content\fsdocs-tips.js = docs\content\fsdocs-tips.js
 		docs\content\fsdocs-theme-toggle.js = docs\content\fsdocs-theme-toggle.js
+		docs\content\fsdocs-theme-set-dark.js = docs\content\fsdocs-theme-set-dark.js
 	EndProjectSection
 EndProject
 Global

--- a/docs/_template.html
+++ b/docs/_template.html
@@ -21,6 +21,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Fira+Code&display=swap" rel="stylesheet">
     <script src="https://code.iconify.design/iconify-icon/1.0.7/iconify-icon.min.js"></script>
     <link href="{{root}}{{fsdocs-favicon-src}}" rel="icon" sizes="32x32" type="image/png"/>
+    <script type="application/javascript" src="{{root}}content/fsdocs-theme-set-dark.js"></script>
     <link href="{{root}}content/fsdocs-default.css" rel="stylesheet" type="text/css"/>
     <link href="{{root}}content/fsdocs-theme.css" rel="stylesheet" type="text/css"/>
     {{fsdocs-head-extra}}

--- a/docs/content/fsdocs-theme-set-dark.js
+++ b/docs/content/fsdocs-theme-set-dark.js
@@ -1,0 +1,5 @@
+const prefersDark = window.matchMedia("@media (prefers-color-scheme: dark)").matches;
+let currentTheme = localStorage.getItem('theme') ?? (prefersDark ? 'dark' : 'light');
+if (currentTheme === 'dark') {
+    window.document.documentElement.setAttribute("data-theme", 'dark');
+}

--- a/docs/content/fsdocs-theme-toggle.js
+++ b/docs/content/fsdocs-theme-toggle.js
@@ -2,9 +2,6 @@
 
 const prefersDark = window.matchMedia("@media (prefers-color-scheme: dark)").matches;
 let currentTheme = localStorage.getItem('theme') ?? (prefersDark ? 'dark' : 'light');
-if (currentTheme === 'dark') {
-    window.document.documentElement.setAttribute("data-theme", 'dark');
-}
 
 export class ThemeToggle extends LitElement {
     static properties = {


### PR DESCRIPTION
Fix found by @TheAngryByrd to avoid the flickering of the dark theme.
