### PR TITLE
Make example command in docs/literate-notebook.ipynb verbose

### DIFF
--- a/docs/literate-notebook.ipynb
+++ b/docs/literate-notebook.ipynb
@@ -2,9 +2,10 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "91a9b093",
    "metadata": {
-    "dotnet_repl_cellExecutionStartTime": "2023-11-22T13:28:54.243692+00:00",
-    "dotnet_repl_cellExecutionEndTime": "2023-11-22T13:28:54.2640212+00:00"
+    "dotnet_repl_cellExecutionEndTime": "2023-11-22T13:28:54.2640212+00:00",
+    "dotnet_repl_cellExecutionStartTime": "2023-11-22T13:28:54.243692+00:00"
    },
    "source": [
     "---\n",
@@ -20,7 +21,7 @@
     "\n",
     "Content may be created using  [.NET interactive](https://github.com/dotnet/interactive/tree/main) polyglot notebooks as the input file. Notebooks are processed by converting the notebook to a literate `.fsx` script and then passing the script through the script processing pipeline. Markdown notebook cells are passed through as comments surrounded by `(**` and `*)`, F# code cells are passed through as code, and non-F# code is passed through as markdown fenced code blocks between `(**` and `*)` comment markers. \n",
     "\n",
-    "The `fsdocs` tool uses [dotnet-repl](https://github.com/jonsequitur/dotnet-repl) to evaluate polyglot notebooks. You need this tool to evaluate notebooks using `dotnet fsdocs --eval`. It can be installed into your local tool manifest using the command `dotnet tool install dotnet-repl`.\n",
+    "The `fsdocs` tool uses [dotnet-repl](https://github.com/jonsequitur/dotnet-repl) to evaluate polyglot notebooks. You need this tool to evaluate notebooks using `dotnet fsdocs [build|watch] --eval`. It can be installed into your local tool manifest using the command `dotnet tool install dotnet-repl`.\n",
     "\n",
     "F# Formatting tries to faithfully reproduce a notebook's native appearance when generating documents. Notebook cell outputs are passed through unchanged to preserve the notebook's html output. The below snippet demonstrates a notebook's html output for F# records, which differs from the output you would get with the same code inside a literate scripts.\n"
    ]
@@ -28,14 +29,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "fdf16de9",
    "metadata": {
-    "dotnet_repl_cellExecutionStartTime": "2023-11-22T13:28:54.265034+00:00",
-    "dotnet_repl_cellExecutionEndTime": "2023-11-22T13:28:56.2484876+00:00",
     "dotnet_interactive": {
      "language": "fsharp"
     },
+    "dotnet_repl_cellExecutionEndTime": "2023-11-22T13:28:56.2484876+00:00",
+    "dotnet_repl_cellExecutionStartTime": "2023-11-22T13:28:54.265034+00:00",
     "polyglot_notebook": {
      "kernelName": "fsharp"
+    },
+    "vscode": {
+     "languageId": "fsharp"
     }
    },
    "outputs": [
@@ -95,6 +100,14 @@
   }
  ],
  "metadata": {
+  "dotnet_interactive": {
+   "defaultKernelName": "fsharp",
+   "items": [
+    {
+     "name": "fsharp"
+    }
+   ]
+  },
   "kernelspec": {
    "display_name": ".NET (F#)",
    "language": "F#",
@@ -108,14 +121,6 @@
    "version": "6.0"
   },
   "polyglot_notebook": {
-   "defaultKernelName": "fsharp",
-   "items": [
-    {
-     "name": "fsharp"
-    }
-   ]
-  },
-  "dotnet_interactive": {
    "defaultKernelName": "fsharp",
    "items": [
     {


### PR DESCRIPTION
Changes use of `dotnet fsdocs --eval` to `dotnet fsdocs [build|watch] --eval`. I should have known but it cost me a bit of time as a beginner so I think the verbosity would help 🙂.