### PR TITLE
Do not set font size on code elements.

### DIFF
--- a/docs/content/fsdocs-default.css
+++ b/docs/content/fsdocs-default.css
@@ -721,7 +721,6 @@ code, table.pre, pre {
     color: var(--code-color);
     font-family: var(--monospace-font);
     font-variant-ligatures: none;
-    font-size: var(--font-200);
     -webkit-text-size-adjust: 100%;
 }
 


### PR DESCRIPTION
Fixes formatting when `code` elements are used inside elements that have a different font size like headers.