### PR TITLE
Minor code clean-ups and performance improvements

### DIFF
--- a/src/Common/Collections.fs
+++ b/src/Common/Collections.fs
@@ -49,7 +49,7 @@ module internal List =
             f x
             g ()
             iterInterleaved f g (y :: tl)
-        | [x] -> f x
+        | [ x ] -> f x
         | [] -> ()
 
     /// Tests whether a list starts with the elements of another

--- a/src/Common/Collections.fs
+++ b/src/Common/Collections.fs
@@ -49,7 +49,7 @@ module internal List =
             f x
             g ()
             iterInterleaved f g (y :: tl)
-        | x :: [] -> f x
+        | [x] -> f x
         | [] -> ()
 
     /// Tests whether a list starts with the elements of another
@@ -90,7 +90,7 @@ module internal List =
                     let other, rest = partitionUntil (f >> not) other
                     yield last, other
                     yield! loop rest
-                | [] when other = [] -> ()
+                | [] when List.isEmpty other -> ()
                 | _ -> invalidArg "" "Should start with true"
             }
 

--- a/src/Common/StringParsing.fs
+++ b/src/Common/StringParsing.fs
@@ -15,8 +15,9 @@ open FSharp.Formatting.Markdown
 
 module String =
     /// Matches when a string is a whitespace or null
+    [<return: Struct>]
     let (|WhiteSpace|_|) (s) =
-        if String.IsNullOrWhiteSpace(s) then Some() else None
+        if String.IsNullOrWhiteSpace(s) then ValueSome() else ValueNone
 
     /// Returns a string trimmed from both start and end
     let (|TrimBoth|) (text: string) = text.Trim()
@@ -117,15 +118,17 @@ module String =
 
 module StringPosition =
     /// Matches when a string is a whitespace or null
+    [<return:Struct>]
     let (|WhiteSpace|_|) (s, _n: MarkdownRange) =
-        if String.IsNullOrWhiteSpace(s) then Some() else None
+        if String.IsNullOrWhiteSpace(s) then ValueSome() else ValueNone
 
     /// Matches when a string does starts with non-whitespace
+    [<return:Struct>]
     let (|Unindented|_|) (s: string, _n: MarkdownRange) =
         if not (String.IsNullOrWhiteSpace(s)) && s.TrimStart() = s then
-            Some()
+            ValueSome()
         else
-            None
+            ValueNone
 
     /// Returns a string trimmed from both start and end
     let (|TrimBoth|) (text: string, n: MarkdownRange) =
@@ -174,11 +177,12 @@ module StringPosition =
              StartColumn = n.StartColumn + text.Length - trimmed.Length })
 
     /// Matches when a string starts with any of the specified sub-strings
+    [<return:Struct>]
     let (|StartsWithAny|_|) (starts: string seq) (text: string, _n: MarkdownRange) =
         if starts |> Seq.exists (fun s -> text.StartsWith(s, StringComparison.Ordinal)) then
-            Some()
+            ValueSome()
         else
-            None
+            ValueNone
 
     /// Matches when a string starts with the specified sub-string
     let (|StartsWith|_|) (start: string) (text: string, n: MarkdownRange) =
@@ -297,15 +301,16 @@ module StringPosition =
 
     /// Matches when a string consists of some number of
     /// complete repetitions of a specified sub-string.
+    [<return:Struct>]
     let (|EqualsRepeated|_|) (repeated, _n: MarkdownRange) =
         function
-        | StartsWithRepeated repeated (_n, (v, _)) when (String.IsNullOrWhiteSpace v) -> Some()
-        | _ -> None
+        | StartsWithRepeated repeated (_n, (v, _)) when (String.IsNullOrWhiteSpace v) -> ValueSome()
+        | _ -> ValueNone
 
 module List =
     /// Matches a list if it starts with a sub-list that is delimited
     /// using the specified delimiters. Returns a wrapped list and the rest.
-    let inline (|DelimitedWith|_|) startl endl input =
+    let inline internal (|DelimitedWith|_|) startl endl input =
         if List.startsWith startl input then
             match List.partitionUntilEquals endl (List.skip startl.Length input) with
             | Some(pre, post) -> Some(pre, List.skip endl.Length post, startl.Length, endl.Length)
@@ -314,14 +319,14 @@ module List =
             None
 
     /// Matches a list if it starts with a sub-list. Returns the list.
-    let inline (|StartsWith|_|) startl input =
+    let inline internal (|StartsWith|_|) startl input =
         if List.startsWith startl input then Some input else None
 
     /// Matches a list if it starts with a sub-list that is delimited
     /// using the specified delimiter. Returns a wrapped list and the rest.
-    let inline (|Delimited|_|) str = (|DelimitedWith|_|) str str
+    let inline internal (|Delimited|_|) str = (|DelimitedWith|_|) str str
 
-    let inline (|DelimitedNTimes|_|) str input =
+    let inline internal (|DelimitedNTimes|_|) str input =
         let strs, _items = List.partitionWhile (fun i -> i = str) input
 
         match strs with
@@ -403,9 +408,8 @@ module Lines =
     let (|TrimParagraphLines|) lines =
         lines
         // first remove all whitespace on the beginning of the line
-        |> List.map (fun (StringPosition.TrimStart s) -> s)
-        // Now remove all additional spaces at the end, but keep two spaces if existent
-        |> List.map (fun (s, n) ->
+        // then remove all additional spaces at the end, but keep two spaces if existent
+        |> List.map (fun (StringPosition.TrimStart (s, n)) ->
             let endsWithTwoSpaces = s.EndsWith("  ", StringComparison.Ordinal)
 
             let trimmed = s.TrimEnd([| ' ' |]) + if endsWithTwoSpaces then "  " else ""

--- a/src/Common/StringParsing.fs
+++ b/src/Common/StringParsing.fs
@@ -17,7 +17,10 @@ module String =
     /// Matches when a string is a whitespace or null
     [<return: Struct>]
     let (|WhiteSpace|_|) (s) =
-        if String.IsNullOrWhiteSpace(s) then ValueSome() else ValueNone
+        if String.IsNullOrWhiteSpace(s) then
+            ValueSome()
+        else
+            ValueNone
 
     /// Returns a string trimmed from both start and end
     let (|TrimBoth|) (text: string) = text.Trim()
@@ -118,12 +121,15 @@ module String =
 
 module StringPosition =
     /// Matches when a string is a whitespace or null
-    [<return:Struct>]
+    [<return: Struct>]
     let (|WhiteSpace|_|) (s, _n: MarkdownRange) =
-        if String.IsNullOrWhiteSpace(s) then ValueSome() else ValueNone
+        if String.IsNullOrWhiteSpace(s) then
+            ValueSome()
+        else
+            ValueNone
 
     /// Matches when a string does starts with non-whitespace
-    [<return:Struct>]
+    [<return: Struct>]
     let (|Unindented|_|) (s: string, _n: MarkdownRange) =
         if not (String.IsNullOrWhiteSpace(s)) && s.TrimStart() = s then
             ValueSome()
@@ -177,7 +183,7 @@ module StringPosition =
              StartColumn = n.StartColumn + text.Length - trimmed.Length })
 
     /// Matches when a string starts with any of the specified sub-strings
-    [<return:Struct>]
+    [<return: Struct>]
     let (|StartsWithAny|_|) (starts: string seq) (text: string, _n: MarkdownRange) =
         if starts |> Seq.exists (fun s -> text.StartsWith(s, StringComparison.Ordinal)) then
             ValueSome()
@@ -301,7 +307,7 @@ module StringPosition =
 
     /// Matches when a string consists of some number of
     /// complete repetitions of a specified sub-string.
-    [<return:Struct>]
+    [<return: Struct>]
     let (|EqualsRepeated|_|) (repeated, _n: MarkdownRange) =
         function
         | StartsWithRepeated repeated (_n, (v, _)) when (String.IsNullOrWhiteSpace v) -> ValueSome()
@@ -409,7 +415,7 @@ module Lines =
         lines
         // first remove all whitespace on the beginning of the line
         // then remove all additional spaces at the end, but keep two spaces if existent
-        |> List.map (fun (StringPosition.TrimStart (s, n)) ->
+        |> List.map (fun (StringPosition.TrimStart(s, n)) ->
             let endsWithTwoSpaces = s.EndsWith("  ", StringComparison.Ordinal)
 
             let trimmed = s.TrimEnd([| ' ' |]) + if endsWithTwoSpaces then "  " else ""

--- a/src/FSharp.Formatting.ApiDocs/Categorise.fs
+++ b/src/FSharp.Formatting.ApiDocs/Categorise.fs
@@ -59,9 +59,9 @@ let entities (nsIndex: int, ns: ApiDocNamespace, suppress) =
                       //
                       // See https://github.com/fsharp/fsharp-core-docs/issues/57, we may rethink this
                       |> List.filter (fun e ->
-                          not (e.Symbol.Namespace = Some "Microsoft.FSharp.Data.UnitSystems.SI.UnitSymbols"))
+                          (e.Symbol.Namespace <> Some "Microsoft.FSharp.Data.UnitSystems.SI.UnitSymbols"))
                       |> List.filter (fun e ->
-                          not (e.Symbol.Namespace = Some "Microsoft.FSharp.Data.UnitSystems.SI.UnitNames"))
+                          (e.Symbol.Namespace <> Some "Microsoft.FSharp.Data.UnitSystems.SI.UnitNames"))
                       // Don't show 'AnonymousObject' in list-of-namespaces navigation
                       |> List.filter (fun e ->
                           not (

--- a/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
+++ b/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
@@ -62,7 +62,7 @@ module internal Utils =
         else
             None
 
-    [<return:Struct>]
+    [<return: Struct>]
     let (|MeasureOne|_|) (typ: FSharpType) =
         if
             typ.HasTypeDefinition
@@ -1758,7 +1758,7 @@ module internal SymbolReader =
             [ let mutable line = ""
 
               while (line <- reader.ReadLine()
-                     not(isNull line)) do
+                     not (isNull line)) do
                   yield line ]
 
         String.removeSpaces lines
@@ -1906,14 +1906,14 @@ module internal SymbolReader =
                     let name = elem.Attribute(XName.Get "name")
                     let nameAsHtml = HttpUtility.HtmlEncode name.Value
 
-                    if not(isNull name) then
+                    if not (isNull name) then
                         html.AppendFormat("<span class=\"fsdocs-param-name\">{0}</span>", nameAsHtml)
                         |> ignore
                 | "see"
                 | "seealso" ->
                     let cref = elem.Attribute(XName.Get "cref")
 
-                    if not(isNull cref) then
+                    if not (isNull cref) then
                         if System.String.IsNullOrEmpty(cref.Value) || cref.Value.Length < 3 then
                             printfn "ignoring invalid cref specified in: %A" e
 
@@ -2019,7 +2019,7 @@ module internal SymbolReader =
         let remarks =
             let remarkNodes = doc.Elements(XName.Get "remarks") |> Seq.toList
 
-            if not(List.isEmpty remarkNodes) then
+            if not (List.isEmpty remarkNodes) then
                 let html = new StringBuilder()
 
                 for (id, e) in List.indexed remarkNodes do
@@ -2054,7 +2054,7 @@ module internal SymbolReader =
             [ for e in exceptionNodes do
                   let cref = e.Attribute(XName.Get "cref")
 
-                  if not(isNull cref) then
+                  if not (isNull cref) then
                       if String.IsNullOrEmpty(cref.Value) || cref.Value.Length < 3 then
                           printfn "Warning: Invalid cref specified in: %A" doc
 
@@ -2822,7 +2822,7 @@ module internal SymbolReader =
             [ for e in doc.Descendants(XName.Get "member") do
                   let attr = e.Attribute(XName.Get "name")
 
-                  if (not(isNull attr)) && not (String.IsNullOrEmpty(attr.Value)) then
+                  if (not (isNull attr)) && not (String.IsNullOrEmpty(attr.Value)) then
                       yield attr.Value, e ] do
             // NOTE: We completely ignore duplicate keys and I don't see
             // an easy way to detect where "value" is coming from, because the entries

--- a/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
+++ b/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
@@ -62,15 +62,16 @@ module internal Utils =
         else
             None
 
+    [<return:Struct>]
     let (|MeasureOne|_|) (typ: FSharpType) =
         if
             typ.HasTypeDefinition
             && typ.TypeDefinition.LogicalName = "1"
             && typ.GenericArguments.Count = 0
         then
-            Some()
+            ValueSome()
         else
-            None
+            ValueNone
 
     let tryGetLocation (symbol: FSharpSymbol) =
         match symbol.ImplementationLocation with
@@ -105,7 +106,7 @@ module internal Utils =
         member x.TryAttr(attr: string) =
             let a = x.Attribute(XName.Get attr)
 
-            if a = null then None
+            if isNull a then None
             else if String.IsNullOrEmpty a.Value then None
             else Some a.Value
 
@@ -1757,7 +1758,7 @@ module internal SymbolReader =
             [ let mutable line = ""
 
               while (line <- reader.ReadLine()
-                     line <> null) do
+                     not(isNull line)) do
                   yield line ]
 
         String.removeSpaces lines
@@ -1905,14 +1906,14 @@ module internal SymbolReader =
                     let name = elem.Attribute(XName.Get "name")
                     let nameAsHtml = HttpUtility.HtmlEncode name.Value
 
-                    if name <> null then
+                    if not(isNull name) then
                         html.AppendFormat("<span class=\"fsdocs-param-name\">{0}</span>", nameAsHtml)
                         |> ignore
                 | "see"
                 | "seealso" ->
                     let cref = elem.Attribute(XName.Get "cref")
 
-                    if cref <> null then
+                    if not(isNull cref) then
                         if System.String.IsNullOrEmpty(cref.Value) || cref.Value.Length < 3 then
                             printfn "ignoring invalid cref specified in: %A" e
 
@@ -2018,7 +2019,7 @@ module internal SymbolReader =
         let remarks =
             let remarkNodes = doc.Elements(XName.Get "remarks") |> Seq.toList
 
-            if List.length remarkNodes > 0 then
+            if not(List.isEmpty remarkNodes) then
                 let html = new StringBuilder()
 
                 for (id, e) in List.indexed remarkNodes do
@@ -2053,7 +2054,7 @@ module internal SymbolReader =
             [ for e in exceptionNodes do
                   let cref = e.Attribute(XName.Get "cref")
 
-                  if cref <> null then
+                  if not(isNull cref) then
                       if String.IsNullOrEmpty(cref.Value) || cref.Value.Length < 3 then
                           printfn "Warning: Invalid cref specified in: %A" doc
 
@@ -2581,7 +2582,7 @@ module internal SymbolReader =
         |> Seq.choose (fun p ->
             let nameAttr = p.Attribute(XName.Get "name")
 
-            if nameAttr = null then
+            if isNull nameAttr then
                 None
             else
                 Some(nameAttr.Value, p.Value))
@@ -2821,7 +2822,7 @@ module internal SymbolReader =
             [ for e in doc.Descendants(XName.Get "member") do
                   let attr = e.Attribute(XName.Get "name")
 
-                  if attr <> null && not (String.IsNullOrEmpty(attr.Value)) then
+                  if (not(isNull attr)) && not (String.IsNullOrEmpty(attr.Value)) then
                       yield attr.Value, e ] do
             // NOTE: We completely ignore duplicate keys and I don't see
             // an easy way to detect where "value" is coming from, because the entries

--- a/src/FSharp.Formatting.CodeFormat/CodeFormatAgent.fs
+++ b/src/FSharp.Formatting.CodeFormat/CodeFormatAgent.fs
@@ -352,7 +352,7 @@ module CodeFormatter =
                 [| let line = ref ""
 
                    while (line := reader.ReadLine()
-                          not(isNull line.Value)) do
+                          not (isNull line.Value)) do
                        yield line.Value |]
             // Get options for a standalone script file (this adds some
             // default references and doesn't require full project information)

--- a/src/FSharp.Formatting.CodeFormat/CodeFormatAgent.fs
+++ b/src/FSharp.Formatting.CodeFormat/CodeFormatAgent.fs
@@ -352,7 +352,7 @@ module CodeFormatter =
                 [| let line = ref ""
 
                    while (line := reader.ReadLine()
-                          line.Value <> null) do
+                          not(isNull line.Value)) do
                        yield line.Value |]
             // Get options for a standalone script file (this adds some
             // default references and doesn't require full project information)

--- a/src/FSharp.Formatting.CodeFormat/SourceCode.fs
+++ b/src/FSharp.Formatting.CodeFormat/SourceCode.fs
@@ -20,7 +20,7 @@ type ToolTipSpan =
     | HardLineBreak
 
 /// Classifies tokens reported by the FCS
-[<RequireQualifiedAccess>]
+[<RequireQualifiedAccess; Struct>]
 type TokenKind =
     | Keyword
     | String
@@ -49,7 +49,7 @@ type TokenKind =
 
 
 /// Represents a kind of error reported from the F# compiler (warning or error)
-[<RequireQualifiedAccess>]
+[<RequireQualifiedAccess; Struct>]
 type ErrorKind =
     | Error
     | Warning

--- a/src/FSharp.Formatting.Common/PynbModel.fs
+++ b/src/FSharp.Formatting.Common/PynbModel.fs
@@ -88,8 +88,7 @@ type Cell =
                       | Some(x) -> string<int> x)
                      (this.outputs |> Array.map string<Output> |> String.concat ",\n")))
             (this.source
-             |> Array.map addLineEnd
-             |> Array.map escapeAndQuote
+             |> Array.map (addLineEnd >> escapeAndQuote)
              |> String.concat ",\n    ")
 
 type Kernelspec =

--- a/src/FSharp.Formatting.Common/Templating.fs
+++ b/src/FSharp.Formatting.Common/Templating.fs
@@ -284,8 +284,7 @@ module internal SimpleTemplating =
              | true, lookupContent -> lookupContent
              | false, _ -> "")
             + (match lookup.TryGetValue ParamKeys.``fsdocs-tooltips`` with
-               | true, lookupTips -> 
-                   "\n\n" + lookupTips
+               | true, lookupTips -> "\n\n" + lookupTips
                | false, _ -> "")
         | Some templateText -> ApplySubstitutionsInText substitutions templateText
 

--- a/src/FSharp.Formatting.Common/Templating.fs
+++ b/src/FSharp.Formatting.Common/Templating.fs
@@ -280,14 +280,13 @@ module internal SimpleTemplating =
             // If there is no template or the template is an empty file, return just document + tooltips (tooltips empty if not HTML)
             let lookup = readOnlyDict substitutions
 
-            (if lookup.ContainsKey ParamKeys.``fsdocs-content`` then
-                 lookup.[ParamKeys.``fsdocs-content``]
-             else
-                 "")
-            + (if lookup.ContainsKey ParamKeys.``fsdocs-tooltips`` then
-                   "\n\n" + lookup.[ParamKeys.``fsdocs-tooltips``]
-               else
-                   "")
+            (match lookup.TryGetValue ParamKeys.``fsdocs-content`` with
+             | true, lookupContent -> lookupContent
+             | false, _ -> "")
+            + (match lookup.TryGetValue ParamKeys.``fsdocs-tooltips`` with
+               | true, lookupTips -> 
+                   "\n\n" + lookupTips
+               | false, _ -> "")
         | Some templateText -> ApplySubstitutionsInText substitutions templateText
 
     let UseFileAsSimpleTemplate (substitutions, templateOpt, outputFile) =

--- a/src/FSharp.Formatting.Common/YaafFSharpScripting.fs
+++ b/src/FSharp.Formatting.Common/YaafFSharpScripting.fs
@@ -247,10 +247,8 @@ module internal CompilerServiceExtensions =
             |> List.map (fun file ->
                 file,
                 (match referenceDict.TryGetValue file with
-                 | true, refFile -> 
-                     Some refFile
-                 | false, _ ->
-                     None))
+                 | true, refFile -> Some refFile
+                 | false, _ -> None))
 
         let getProjectReferencesSimple frameworkVersion (dllFiles: string list) =
             getProjectReferences frameworkVersion None None dllFiles |> resolve dllFiles
@@ -465,7 +463,7 @@ module internal ArgParser =
         else
             None
 
-    [<return:Struct>]
+    [<return: Struct>]
     let (|FsiBoolArg|_|) argName s =
         match s with
         | StartsWith argName rest ->

--- a/src/FSharp.Formatting.Literate/Contexts.fs
+++ b/src/FSharp.Formatting.Literate/Contexts.fs
@@ -23,7 +23,7 @@ type internal CompilerContext =
     }
 
 /// Defines the possible output types from literate script (HTML, Latex, Pynb)
-[<RequireQualifiedAccess>]
+[<RequireQualifiedAccess; Struct>]
 type OutputKind =
     /// Requests HTML output
     | Html

--- a/src/FSharp.Formatting.Literate/Evaluator.fs
+++ b/src/FSharp.Formatting.Literate/Evaluator.fs
@@ -15,7 +15,7 @@ open FSharp.Formatting.Internal
 /// <namespacedoc>
 ///   <summary>Functionality to support literate evaluation for F# scripts</summary>
 /// </namespacedoc>
-[<RequireQualifiedAccessAttribute>]
+[<RequireQualifiedAccessAttribute; Struct>]
 type FsiEmbedKind =
     /// The FSI output
     | FsiOutput

--- a/src/FSharp.Formatting.Literate/ParseScript.fs
+++ b/src/FSharp.Formatting.Literate/ParseScript.fs
@@ -163,8 +163,9 @@ type internal ParseScript(parseOptions, ctx: CompilerContext) =
         | Command "condition" name when not (String.IsNullOrWhiteSpace name) -> { Condition = Some name }
         | _ -> { Condition = None }
 
-    [<return:Struct>]
-    let (|EmptyString|_|) (v: string) = if v.Length = 0 then ValueSome() else ValueNone
+    [<return: Struct>]
+    let (|EmptyString|_|) (v: string) =
+        if v.Length = 0 then ValueSome() else ValueNone
 
     /// Transform list of code blocks (snippet/comment/command)
     /// into a formatted Markdown document, with link definitions
@@ -387,7 +388,7 @@ type internal ParseScript(parseOptions, ctx: CompilerContext) =
 
         let parsedBlocks =
             [ for Snippet(name, lines) in sourceSnippets do
-                  if not(isNull name) then
+                  if not (isNull name) then
                       yield BlockComment("## " + name)
 
                   yield! parseScriptFile (lines) ]

--- a/src/FSharp.Formatting.Literate/ParseScript.fs
+++ b/src/FSharp.Formatting.Literate/ParseScript.fs
@@ -163,7 +163,8 @@ type internal ParseScript(parseOptions, ctx: CompilerContext) =
         | Command "condition" name when not (String.IsNullOrWhiteSpace name) -> { Condition = Some name }
         | _ -> { Condition = None }
 
-    let (|EmptyString|_|) (v: string) = if v.Length = 0 then Some() else None
+    [<return:Struct>]
+    let (|EmptyString|_|) (v: string) = if v.Length = 0 then ValueSome() else ValueNone
 
     /// Transform list of code blocks (snippet/comment/command)
     /// into a formatted Markdown document, with link definitions
@@ -386,7 +387,7 @@ type internal ParseScript(parseOptions, ctx: CompilerContext) =
 
         let parsedBlocks =
             [ for Snippet(name, lines) in sourceSnippets do
-                  if name <> null then
+                  if not(isNull name) then
                       yield BlockComment("## " + name)
 
                   yield! parseScriptFile (lines) ]

--- a/src/FSharp.Formatting.Literate/Transformations.fs
+++ b/src/FSharp.Formatting.Literate/Transformations.fs
@@ -77,8 +77,7 @@ module internal Transformations =
                             |> Array.toList
                             |> String.removeSpaces
                             |> String.concat "\n"
-                        | _ ->
-                            code
+                        | _ -> code
 
                     let lang =
                         match language with

--- a/src/FSharp.Formatting.Literate/Transformations.fs
+++ b/src/FSharp.Formatting.Literate/Transformations.fs
@@ -60,11 +60,12 @@ module internal Transformations =
                     None
                 else
                     let code =
-                        if cmds.ContainsKey("file") && cmds.ContainsKey("key") then
+                        match cmds.TryGetValue "file", cmds.TryGetValue "key" with
+                        | (true, fileVal), (true, keyVal) ->
                             // Get snippet from an external file
-                            let file = Path.Combine(Path.GetDirectoryName(path), cmds.["file"])
+                            let file = Path.Combine(Path.GetDirectoryName(path), fileVal)
 
-                            let startTag, endTag = "[" + cmds.["key"] + "]", "[/" + cmds.["key"] + "]"
+                            let startTag, endTag = "[" + keyVal + "]", "[/" + keyVal + "]"
 
                             let lines = File.ReadAllLines(file)
 
@@ -76,7 +77,7 @@ module internal Transformations =
                             |> Array.toList
                             |> String.removeSpaces
                             |> String.concat "\n"
-                        else
+                        | _ ->
                             code
 
                     let lang =

--- a/src/FSharp.Formatting.Markdown/Markdown.fs
+++ b/src/FSharp.Formatting.Markdown/Markdown.fs
@@ -45,7 +45,7 @@ type Markdown internal () =
               let mutable lineNo = 1
 
               while (line := reader.ReadLine()
-                     line.Value <> null) do
+                     not(isNull line.Value)) do
                   yield
                       (line.Value,
                        { StartLine = lineNo

--- a/src/FSharp.Formatting.Markdown/Markdown.fs
+++ b/src/FSharp.Formatting.Markdown/Markdown.fs
@@ -45,7 +45,7 @@ type Markdown internal () =
               let mutable lineNo = 1
 
               while (line := reader.ReadLine()
-                     not(isNull line.Value)) do
+                     not (isNull line.Value)) do
                   yield
                       (line.Value,
                        { StartLine = lineNo

--- a/src/FSharp.Formatting.Markdown/MarkdownModel.fs
+++ b/src/FSharp.Formatting.Markdown/MarkdownModel.fs
@@ -14,11 +14,13 @@ open System.Collections.Generic
 /// <summary>
 ///   A list kind can be Ordered or Unordered corresponding to <c>&lt;ol&gt;</c> and <c>&lt;ul&gt;</c> elements
 /// </summary>
+[<Struct>]
 type MarkdownListKind =
     | Ordered
     | Unordered
 
 /// Column in a table can be aligned to left, right, center or using the default alignment
+[<Struct>]
 type MarkdownColumnAlignment =
     | AlignLeft
     | AlignRight

--- a/src/FSharp.Formatting.Markdown/MarkdownParser.fs
+++ b/src/FSharp.Formatting.Markdown/MarkdownParser.fs
@@ -844,7 +844,7 @@ let rec pipeTableFindSplits (delim: char array) (line: char list) =
 
     match rest with
     | None -> [ cLstToStr line ]
-    | Some _x when line = [] -> [ "" ]
+    | Some _x when List.isEmpty line -> [ "" ]
     | Some x ->
         let chunkSize = List.length line - List.length x - 1
 

--- a/src/fsdocs-tool/BuildCommand.fs
+++ b/src/fsdocs-tool/BuildCommand.fs
@@ -695,7 +695,7 @@ type internal DocContent
                   | (inputFileFullPath, isOtherLang, model) when
                       not isOtherLang
                       && model.OutputKind = OutputKind.Html
-                      && not (Path.GetFileNameWithoutExtension(inputFileFullPath) = "index")
+                      && (Path.GetFileNameWithoutExtension(inputFileFullPath) <> "index")
                       ->
                       { model with
                           IsActive =

--- a/src/fsdocs-tool/ProjectCracker.fs
+++ b/src/fsdocs-tool/ProjectCracker.fs
@@ -161,11 +161,12 @@ module DotNetCli =
 
 module Crack =
 
+    [<return:Struct>]
     let (|ConditionEquals|_|) (str: string) (arg: string) =
         if System.String.Compare(str, arg, System.StringComparison.OrdinalIgnoreCase) = 0 then
-            Some()
+            ValueSome()
         else
-            None
+            ValueNone
 
     let msbuildPropBool (s: string) =
         let trimmed = s.Trim()

--- a/src/fsdocs-tool/ProjectCracker.fs
+++ b/src/fsdocs-tool/ProjectCracker.fs
@@ -161,7 +161,7 @@ module DotNetCli =
 
 module Crack =
 
-    [<return:Struct>]
+    [<return: Struct>]
     let (|ConditionEquals|_|) (str: string) (arg: string) =
         if System.String.Compare(str, arg, System.StringComparison.OrdinalIgnoreCase) = 0 then
             ValueSome()

--- a/tests/FSharp.CodeFormat.Tests/CodeFormatTests.fs
+++ b/tests/FSharp.CodeFormat.Tests/CodeFormatTests.fs
@@ -23,6 +23,7 @@ let containsSpan f snips =
     |> Seq.exists (fun (Snippet(_, lines)) -> lines |> Seq.exists (fun (Line(_, spans)) -> spans |> Seq.exists f))
 
 // Check that tool tips contains a specified token
+[<return: Struct>]
 let (|ToolTipWithLiteral|_|) text tips =
     if
         Seq.exists
@@ -31,9 +32,9 @@ let (|ToolTipWithLiteral|_|) text tips =
             | _ -> false)
             tips
     then
-        Some()
+        ValueSome()
     else
-        None
+        ValueNone
 
 // --------------------------------------------------------------------------------------
 // Test that some basic things work


### PR DESCRIPTION
Code clean-up with minor performance optimizations:

- isNull instead of "= null": https://latkin.org/blog/2015/05/18/null-checking-considerations-in-f-its-harder-than-you-think/
- TryGetValue instead of double-lookups of dictionaries
- Types and active patterns that are not containing any data can be structs to reduce object capsuling and memory footprint
- inline functions preferably internal to not leak outside of the project

No functional changes.