### PR TITLE
make code command line copy-able

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Once built, you can run the command-line tool to self-build the docs for this di
 ### Pipelines
 
 Run
+
     dotnet fsi build.fsx -- --help
 
 to see what other pipelines can be run from `build.fsx`.


### PR DESCRIPTION
Update README.md
the command `dotnet fsi build.fsx -- --help` was indented 4 spaces to make it code block, but on github it apparently needs a blank line above it to box it out and make it have the "clipboard copy" button appear.  The rendered page shows "Run dotnet fsi build.fsx -- --help" instead of a code block.  Just added the additional blank line.

# Before you go

Hi there! Thank you for your contribution to our project. To help maintain the quality of our codebase, our Continuous Integration (CI) system will automatically run several checks on your submission. To streamline the process, we kindly ask you to perform these checks locally before pushing your changes:

To execute all build scripts, please run:

```shell
dotnet fsi build.fsx
```

If you encounter any formatting issues, you can auto-correct them by running:

```shell
dotnet fantomas build.fsx src tests docs
```

Should any tests fail, please review and adjust your changes accordingly.

We appreciate your efforts to contribute and look forward to reviewing your pull request!
