### PR TITLE
Details improvements

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 20.0.1 - 2024-05-31
+* Details improvements. [#917](https://github.com/fsprojects/FSharp.Formatting/pull/917)
+
 ## 20.0.0 - 2024-02-14
 
 Stable release

--- a/docs/content/fsdocs-default.css
+++ b/docs/content/fsdocs-default.css
@@ -1013,29 +1013,32 @@ span[onmouseout] {
         padding: var(--spacing-400) 0;
     }
 
-    & tbody td {
-        border-top: 1px solid var(--header-border);
-        padding: var(--spacing-300) 0;
-        padding-right: var(--spacing-300);
+    & tr {
+        display: flex;
+        flex-flow: row wrap;
+        column-gap: 1rem;
 
-        &:first-child a {
+        & td:first-of-type {
+            flex: 25 0 0;
+            min-width: 20em;
             overflow-x: hidden;
             text-overflow: ellipsis;
-            width: 100%;
-            display: block;
+            overflow-wrap: break-word;
+
+            & p {
+                margin: unset;
+            }
         }
 
-        &:last-child {
-            padding-right: 0;
+        & td:nth-of-type(2) {
+            flex: 75 0 0;
+            min-width: 15em;
         }
     }
 
-    & thead tr td:first-child, & td.fsdocs-entity-name, & td.fsdocs-member-usage {
-        width: 25%;
-
-        & p {
-            margin: 0;
-        }
+    & tbody td {
+        border-top: 1px solid var(--header-border);
+        padding: var(--spacing-300) 0;
     }
 
     .fsdocs-entity-xmldoc {
@@ -1061,7 +1064,11 @@ span[onmouseout] {
 
     .fsdocs-member-xmldoc {
         & summary {
-            list-style: none;
+            display: list-item;
+            counter-increment: list-item 0;
+            list-style: disclosure-closed outside;
+            cursor: pointer;
+            margin-left: 1rem;
 
             > .fsdocs-summary {
                 display: flex;
@@ -1080,23 +1087,15 @@ span[onmouseout] {
                     overflow-x: auto;
                 }
             }
-
-            &::after {
-                content: '▶';
-                cursor: pointer;
-            }
         }
 
         & details[open] summary {
+            list-style-type: disclosure-open;
             margin-bottom: var(--spacing-200);
         }
 
-        & details[open] summary::after {
-            content: "▼";
-        }
-
         .fsdocs-returns, .fsdocs-params {
-            margin: var(--spacing-200) 0;
+            margin: var(--spacing-200);
 
             &:first-child {
                 margin-top: 0;
@@ -1109,23 +1108,6 @@ span[onmouseout] {
 
         .fsdocs-return-name, .fsdocs-param-name {
             font-weight: 500;
-        }
-
-        /* hide the browser mark and display one after the summary */
-
-        & ::marker {
-            display: none;
-        }
-
-        > div.fsdocs-summary {
-            display: flex;
-            flex-direction: row-reverse;
-            justify-content: space-between;
-            align-items: center;
-
-            > p {
-                margin: 0;
-            }
         }
     }
 }

--- a/docs/content/fsdocs-default.css
+++ b/docs/content/fsdocs-default.css
@@ -1046,7 +1046,7 @@ span[onmouseout] {
             display: flex;
             flex-direction: row-reverse;
             justify-content: flex-start;
-            align-items: center;
+            align-items: flex-start;
 
             & p.fsdocs-summary {
                 margin: 0;
@@ -1072,8 +1072,9 @@ span[onmouseout] {
 
             > .fsdocs-summary {
                 display: flex;
-                align-items: center;
                 flex-direction: row-reverse;
+                justify-content: flex-start;
+                align-items: flex-start;
 
                 & p.fsdocs-summary {
                     margin: 0;

--- a/docs/content/fsdocs-default.css
+++ b/docs/content/fsdocs-default.css
@@ -47,6 +47,8 @@
     --main-grid-row: 2;
     --main-grid-column: 2;
     --dialog-width: 500px;
+    --api-docs-first-column-min-width: 320px;
+    --api-docs-second-column-min-width: 240px;
 
     /* light theme */
     --primary: #1e8bc3;
@@ -1016,11 +1018,11 @@ span[onmouseout] {
     & tr {
         display: flex;
         flex-flow: row wrap;
-        column-gap: 1rem;
+        column-gap: var(--spacing-300);
 
         & td:first-of-type {
             flex: 25 0 0;
-            min-width: 20em;
+            min-width: var(--api-docs-first-column-min-width);
             overflow-x: hidden;
             text-overflow: ellipsis;
             overflow-wrap: break-word;
@@ -1032,7 +1034,7 @@ span[onmouseout] {
 
         & td:nth-of-type(2) {
             flex: 75 0 0;
-            min-width: 15em;
+            min-width: var(--api-docs-second-column-min-width);
         }
     }
 
@@ -1068,7 +1070,7 @@ span[onmouseout] {
             counter-increment: list-item 0;
             list-style: disclosure-closed outside;
             cursor: pointer;
-            margin-left: 1rem;
+            margin-left: var(--spacing-300);
 
             > .fsdocs-summary {
                 display: flex;

--- a/docs/content/fsdocs-theme.js
+++ b/docs/content/fsdocs-theme.js
@@ -14,10 +14,10 @@ if (activeItem && mainMenu) {
 
 function scrollToAndExpandSelectedMember() {
     if (location.hash) {
-        const header = document.querySelector(`a[href='${location.hash}']`);
-        header.scrollIntoView({ behavior: 'instant'});
         const details = document.querySelector(`tr > td.fsdocs-member-usage:has(a[href='${location.hash}']) ~ td.fsdocs-member-xmldoc > details`);
         details?.setAttribute('open', 'true');
+        const header = document.querySelector(`a[href='${location.hash}']`);
+        header.scrollIntoView({ behavior: 'instant'});
     }
 }
 

--- a/docs/content/fsdocs-theme.js
+++ b/docs/content/fsdocs-theme.js
@@ -22,7 +22,7 @@ function scrollToAndExpandSelectedMember() {
 }
 
 scrollToAndExpandSelectedMember();
-addEventListener('hashchange', _event => scrollToAndExpandSelectedMember());
+addEventListener('hashchange', scrollToAndExpandSelectedMember);
 
 if(location.pathname.startsWith('/reference/')) {
     // Scroll to API Reference header

--- a/docs/content/fsdocs-theme.js
+++ b/docs/content/fsdocs-theme.js
@@ -12,10 +12,17 @@ if (activeItem && mainMenu) {
     scrollToActiveItem(activeItem);
 }
 
-if(location.hash) {
-    const header = document.querySelector(`a[href='${location.hash}']`);
-    header.scrollIntoView({ behavior: 'instant'});
+function scrollToAndExpandSelectedMember() {
+    if (location.hash) {
+        const header = document.querySelector(`a[href='${location.hash}']`);
+        header.scrollIntoView({ behavior: 'instant'});
+        const details = document.querySelector(`tr > td.fsdocs-member-usage:has(a[href='${location.hash}']) ~ td.fsdocs-member-xmldoc > details`);
+        details?.setAttribute('open', 'true');
+    }
 }
+
+scrollToAndExpandSelectedMember();
+addEventListener('hashchange', _event => scrollToAndExpandSelectedMember());
 
 if(location.pathname.startsWith('/reference/')) {
     // Scroll to API Reference header

--- a/docs/content/fsdocs-theme.js
+++ b/docs/content/fsdocs-theme.js
@@ -17,7 +17,7 @@ function scrollToAndExpandSelectedMember() {
         const details = document.querySelector(`tr > td.fsdocs-member-usage:has(a[href='${location.hash}']) ~ td.fsdocs-member-xmldoc > details`);
         details?.setAttribute('open', 'true');
         const header = document.querySelector(`a[href='${location.hash}']`);
-        header.scrollIntoView({ behavior: 'instant'});
+        header?.scrollIntoView({ behavior: 'instant'});
     }
 }
 


### PR DESCRIPTION
Fixes (part of) #916.

- Auto-expand the details of the selected member, including when linked directly to (via the fragment portion of the URL).
  
  https://github.com/fsprojects/FSharp.Formatting/assets/14795984/3c8a404a-3754-4f7f-b461-c5a97f3ffc7e

- Keep member name aligned to the top left, i.e., don't shift around when details are expanded. This was the original behavior in #818.

  https://github.com/fsprojects/FSharp.Formatting/assets/14795984/2d527fbf-baba-4153-bf1c-6d71ea16c77b

- Put the details marker back before the summary. (This is how it was before and how `details` normally works... The arrow on its own line as it is in `main` looks very odd to me.)

  ![image](https://github.com/fsprojects/FSharp.Formatting/assets/14795984/ab820db4-13e6-48ca-a0e8-db9be4250d8d)

- Make the table readable on mobile by wrapping rows when the screen is too narrow.

  https://github.com/fsprojects/FSharp.Formatting/assets/14795984/179fc73c-a9e5-468f-93d4-066b604cec95

- Align copy icons, etc., to flex-start instead of [center](https://tonsky.me/blog/centering/) to match member name alignment

  #### Before
  ![image](https://github.com/fsprojects/FSharp.Formatting/assets/14795984/0cf858e5-27d4-4ab8-9171-b764774d04ac)

  #### After
  ![image](https://github.com/fsprojects/FSharp.Formatting/assets/14795984/dbd7187b-ef78-48b2-8053-57fb9adb211b)
