### PR TITLE
More details/member docs tweaks

### DIFF
--- a/docs/content/fsdocs-default.css
+++ b/docs/content/fsdocs-default.css
@@ -1046,14 +1046,9 @@ span[onmouseout] {
     .fsdocs-entity-xmldoc {
         > div {
             display: flex;
-            flex-direction: row-reverse;
-            justify-content: flex-start;
+            flex-direction: row;
+            justify-content: space-between;
             align-items: flex-start;
-
-            & p.fsdocs-summary {
-                margin: 0;
-                flex-grow: 1;
-            }
 
             & pre {
                 margin-bottom: var(--spacing-200);
@@ -1064,18 +1059,41 @@ span[onmouseout] {
         }
     }
 
+    .fsdocs-summary-contents {
+        display: flex;
+        flex-direction: column;
+        justify-content: flex-start;
+        align-items: flex-start;
+    }
+
+    .fsdocs-member-xmldoc-column {
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+        justify-content: flex-start;
+    }
+
+    .icon-button-row {
+        display: flex;
+        flex-direction: row;
+        justify-content: flex-end;
+        align-items: flex-start;
+        height: calc(-1 * var(--spacing-200));
+    }
+
     .fsdocs-member-xmldoc {
         & summary {
             display: list-item;
             counter-increment: list-item 0;
             list-style: disclosure-closed outside;
             cursor: pointer;
+            width: calc(100% - var(--spacing-300));
             margin-left: var(--spacing-300);
 
             > .fsdocs-summary {
                 display: flex;
-                flex-direction: row-reverse;
-                justify-content: flex-start;
+                flex-direction: row;
+                justify-content: space-between;
                 align-items: flex-start;
 
                 & p.fsdocs-summary {
@@ -1111,6 +1129,13 @@ span[onmouseout] {
 
         .fsdocs-return-name, .fsdocs-param-name {
             font-weight: 500;
+        }
+
+        > div.fsdocs-summary {
+            display: flex;
+            flex-direction: row;
+            justify-content: space-between;
+            align-items: flex-start;
         }
     }
 }

--- a/src/FSharp.Formatting.ApiDocs/GenerateHtml.fs
+++ b/src/FSharp.Formatting.ApiDocs/GenerateHtml.fs
@@ -18,7 +18,7 @@ let fsdocsSummary (x: ApiDocHtml) =
     if x.HtmlText.StartsWith("<pre>", StringComparison.Ordinal) then
         embed x
     else
-        p [ Class "fsdocs-summary" ] [ embed x ]
+        div [ Class "fsdocs-summary-contents" ] [ p [ Class "fsdocs-summary" ] [ embed x ] ]
 
 type HtmlRender(model: ApiDocModel, ?menuTemplateFolder: string) =
     let root = model.Root
@@ -182,10 +182,12 @@ type HtmlRender(model: ApiDocModel, ?menuTemplateFolder: string) =
 
                               let smry =
                                   div [ Class "fsdocs-summary" ] [
-                                      yield! copyXmlSigIconForSymbolMarkdown m.Symbol
-                                      yield! copyXmlSigIconForSymbol m.Symbol
-                                      yield! sourceLink m.SourceLocation
                                       fsdocsSummary m.Comment.Summary
+                                      div [ Class "icon-button-row" ] [
+                                          yield! sourceLink m.SourceLocation
+                                          yield! copyXmlSigIconForSymbol m.Symbol
+                                          yield! copyXmlSigIconForSymbolMarkdown m.Symbol
+                                      ]
                                   ]
 
                               let dtls =
@@ -272,7 +274,10 @@ type HtmlRender(model: ApiDocModel, ?menuTemplateFolder: string) =
                                   if List.isEmpty dtls then
                                       smry
                                   elif String.IsNullOrWhiteSpace(m.Comment.Summary.HtmlText) then
-                                      yield! dtls
+                                      div [ Class "fsdocs-member-xmldoc-column" ] [
+                                          div [ Class "icon-button-row" ] (sourceLink m.SourceLocation)
+                                          yield! dtls
+                                      ]
                                   else
                                       details [] ((summary [] [ smry ]) :: dtls)
                               ]
@@ -325,10 +330,12 @@ type HtmlRender(model: ApiDocModel, ?menuTemplateFolder: string) =
                               ]
                               td [ Class "fsdocs-entity-xmldoc" ] [
                                   div [] [
-                                      yield! copyXmlSigIconForSymbolMarkdown e.Symbol
-                                      yield! copyXmlSigIconForSymbol e.Symbol
-                                      yield! sourceLink e.SourceLocation
                                       fsdocsSummary e.Comment.Summary
+                                      div [ Class "icon-button-row" ] [
+                                          yield! sourceLink e.SourceLocation
+                                          yield! copyXmlSigIconForSymbol e.Symbol
+                                          yield! copyXmlSigIconForSymbolMarkdown e.Symbol
+                                      ]
                                   ]
                               ]
                           ]


### PR DESCRIPTION
Followup to #917.

- Fix display of member docs for members without other details (e.g., [nullary void-returning methods](https://github.com/dotnet/fsharp/blob/bcffdf70f5d5df156baee6c8e3e8a589bdadd739/src/Compiler/Service/service.fsi#L432-L433)). (https://github.com/fsprojects/FSharp.Formatting/issues/916#issuecomment-2141429522)
- Nest icon buttons in member doc summary in their own `<div>` so that we don't need to use `row-reverse`. This means that any paragraphs (via `<para>`) in the `<summary>` are actually shown in the right order. Paragraphs are also now shown vertically separated instead of horizontally separated. (https://github.com/fsprojects/FSharp.Formatting/issues/916#issuecomment-2141792974)
- Show a source link even when there is no summary XML doc. (https://github.com/fsprojects/FSharp.Formatting/issues/916#issuecomment-2141884878)