### PR TITLE
Add expand/collapse-all button for API doc details

### DIFF
--- a/docs/_template.html
+++ b/docs/_template.html
@@ -22,6 +22,7 @@
     <script src="https://code.iconify.design/iconify-icon/1.0.7/iconify-icon.min.js"></script>
     <link href="{{root}}{{fsdocs-favicon-src}}" rel="icon" sizes="32x32" type="image/png"/>
     <script type="application/javascript" src="{{root}}content/fsdocs-theme-set-dark.js"></script>
+    <script type="application/javascript" src="{{root}}content/fsdocs-details-set-expanded.js"></script>
     <link href="{{root}}content/fsdocs-default.css" rel="stylesheet" type="text/css"/>
     <link href="{{root}}content/fsdocs-theme.css" rel="stylesheet" type="text/css"/>
     {{fsdocs-head-extra}}
@@ -93,6 +94,7 @@
 </dialog>
 <script type="module" src="{{root}}content/fsdocs-tips.js"></script>
 <script type="module" src="{{root}}content/fsdocs-theme-toggle.js"></script>
+<script type="module" src="{{root}}content/fsdocs-details-toggle.js"></script>
 <script type="module" src="{{root}}content/fsdocs-theme.js"></script>
 <script type="module" src="{{root}}content/fsdocs-search.js"></script>
 {{fsdocs-body-extra}}

--- a/docs/content/fsdocs-default.css
+++ b/docs/content/fsdocs-default.css
@@ -1000,6 +1000,13 @@ span[onmouseout] {
     margin-top: 0;
 }
 
+.fsdocs-description-heading {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: flex-start;
+}
+
 .fsdocs-xmldoc {
     & pre {
         overflow-x: auto;

--- a/docs/content/fsdocs-default.css
+++ b/docs/content/fsdocs-default.css
@@ -1000,7 +1000,7 @@ span[onmouseout] {
     margin-top: 0;
 }
 
-.fsdocs-description-heading {
+.fsdocs-member-list-header {
     display: flex;
     flex-direction: row;
     justify-content: space-between;

--- a/docs/content/fsdocs-details-set-expanded.js
+++ b/docs/content/fsdocs-details-set-expanded.js
@@ -1,0 +1,9 @@
+const expandDetails = !!JSON.parse(localStorage.getItem('details-expanded'));
+
+addEventListener('load', _ => {
+    if (expandDetails) {
+        for (const details of document.getElementsByTagName('details')) {
+            details.setAttribute('open', 'true');
+        }
+    }
+});

--- a/docs/content/fsdocs-details-toggle.js
+++ b/docs/content/fsdocs-details-toggle.js
@@ -19,7 +19,6 @@ export class DetailsToggle extends LitElement {
     static styles = css`
       :host {
         cursor: pointer;
-        transform: translateY(3px);
       }
     `;
 

--- a/docs/content/fsdocs-details-toggle.js
+++ b/docs/content/fsdocs-details-toggle.js
@@ -1,0 +1,50 @@
+import { LitElement, html, css } from 'https://cdn.jsdelivr.net/gh/lit/dist@3/core/lit-core.min.js';
+
+const detailsExpanded = !!JSON.parse(localStorage.getItem('details-expanded'));
+
+export class DetailsToggle extends LitElement {
+    static properties = {
+        _detailsExpanded: { state: true, type: Boolean },
+    };
+
+    constructor() {
+        super();
+        this._detailsExpanded = detailsExpanded;
+        document.addEventListener('detailstoggled', e => {
+            this._detailsExpanded = !!e?.detail?.expanding;
+            this.render();
+        });
+    }
+
+    static styles = css`
+      :host {
+        cursor: pointer;
+        transform: translateY(3px);
+      }
+    `;
+
+    toggleDetails() {
+        this._detailsExpanded = !this._detailsExpanded;
+        localStorage.setItem('details-expanded', JSON.stringify(this._detailsExpanded));
+        if (this._detailsExpanded) {
+            for (const details of document.getElementsByTagName('details')) {
+                details.setAttribute('open', 'true');
+            }
+        } else {
+            for (const details of document.getElementsByTagName('details')) {
+                details.removeAttribute('open');
+            }
+        }
+        document.dispatchEvent(new CustomEvent('detailstoggled', { detail: { expanding: this._detailsExpanded } }));
+    }
+
+    render() {
+        const icon = this._detailsExpanded ? 'carbon:collapse-categories' : 'carbon:expand-categories';
+        const title = this._detailsExpanded ? 'Collapse details' : 'Expand details';
+        return html`
+            <iconify-icon width="24" height="24" icon="${icon}" title="${title}" style="color:var(--header-link-color)" @click=${this.toggleDetails}></iconify-icon>
+        `;
+    }
+}
+
+customElements.define('fsdocs-details-toggle', DetailsToggle);

--- a/docs/content/fsdocs-details-toggle.js
+++ b/docs/content/fsdocs-details-toggle.js
@@ -10,10 +10,7 @@ export class DetailsToggle extends LitElement {
     constructor() {
         super();
         this._detailsExpanded = detailsExpanded;
-        document.addEventListener('detailstoggled', e => {
-            this._detailsExpanded = !!e?.detail?.expanding;
-            this.render();
-        });
+        document.addEventListener('detailstoggled', e => this._detailsExpanded = !!e?.detail?.expanding);
     }
 
     static styles = css`

--- a/src/FSharp.Formatting.ApiDocs/GenerateHtml.fs
+++ b/src/FSharp.Formatting.ApiDocs/GenerateHtml.fs
@@ -109,7 +109,9 @@ type HtmlRender(model: ApiDocModel, ?menuTemplateFolder: string) =
                   thead [] [
                       tr [] [
                           td [ Class "fsdocs-member-list-header" ] [ !!tableHeader ]
-                          td [ Class "fsdocs-member-list-header" ] [ !! "Description" ]
+                          td [ Class "fsdocs-member-list-header" ] [
+                              div [ Class "fsdocs-description-heading" ] [ !! "Description"; fsdocsDetailsToggle [] ]
+                          ]
                       ]
                   ]
                   tbody [] [

--- a/src/FSharp.Formatting.ApiDocs/GenerateHtml.fs
+++ b/src/FSharp.Formatting.ApiDocs/GenerateHtml.fs
@@ -109,9 +109,7 @@ type HtmlRender(model: ApiDocModel, ?menuTemplateFolder: string) =
                   thead [] [
                       tr [] [
                           td [ Class "fsdocs-member-list-header" ] [ !!tableHeader ]
-                          td [ Class "fsdocs-member-list-header" ] [
-                              div [ Class "fsdocs-description-heading" ] [ !! "Description"; fsdocsDetailsToggle [] ]
-                          ]
+                          td [ Class "fsdocs-member-list-header" ] [ !! "Description"; fsdocsDetailsToggle [] ]
                       ]
                   ]
                   tbody [] [

--- a/src/FSharp.Formatting.Common/HtmlModel.fs
+++ b/src/FSharp.Formatting.Common/HtmlModel.fs
@@ -751,5 +751,6 @@ module internal Html =
     let iconifyIcon (props: HtmlProperties list) =
         HtmlElement.CustomElement("iconify-icon", props, [])
 
+    /// Toggle button for API doc details.
     let fsdocsDetailsToggle (props: HtmlProperties list) =
         HtmlElement.CustomElement("fsdocs-details-toggle", props, [])

--- a/src/FSharp.Formatting.Common/HtmlModel.fs
+++ b/src/FSharp.Formatting.Common/HtmlModel.fs
@@ -750,3 +750,6 @@ module internal Html =
     /// Web component from https://iconify.design/docs/
     let iconifyIcon (props: HtmlProperties list) =
         HtmlElement.CustomElement("iconify-icon", props, [])
+
+    let fsdocsDetailsToggle (props: HtmlProperties list) =
+        HtmlElement.CustomElement("fsdocs-details-toggle", props, [])


### PR DESCRIPTION
Addresses the other suggestion in #916.

- Add button for expanding/collapsing all member doc details.

https://github.com/fsprojects/FSharp.Formatting/assets/14795984/70041395-4893-474d-a297-7651265624c9

I have the buttons operating on the entire document. When toggled, the preference (all expanded or all collapsed) is saved to local storage. An alternative could have been to have independent expand/collapse-all buttons for each section (e.g., constructors instance members, static members, etc.), and no persistence to local storage.

To maintain parity with the behavior of the theme toggle button, I have the new button showing the state that clicking it will _cause_ rather than the current state, even though I think I might personally prefer it the other way around.