### PR TITLE
Minor Seq Optimizations

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "fsharp-analyzers": {
-      "version": "0.24.0",
+      "version": "0.26.0",
       "commands": [
         "fsharp-analyzers"
       ]

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,7 +27,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="Ionide.KeepAChangelog.Tasks" Version="0.1.8" />
     <PackageVersion Include="FSharp.Analyzers.Build" Version="0.3.0" />
-    <PackageVersion Include="G-Research.FSharp.Analyzers" Version="0.8.0" />
-    <PackageVersion Include="Ionide.Analyzers" Version="0.8.0" />
+    <PackageVersion Include="G-Research.FSharp.Analyzers" Version="0.10.0" />
+    <PackageVersion Include="Ionide.Analyzers" Version="0.11.0" />
   </ItemGroup>
 </Project>

--- a/src/Common/StringParsing.fs
+++ b/src/Common/StringParsing.fs
@@ -109,7 +109,7 @@ module String =
         let spaces =
             lines
             |> Seq.choose (fun line ->
-                if not <| String.IsNullOrWhiteSpace line then
+                if String.IsNullOrWhiteSpace line |> not then
                     line |> Seq.takeWhile Char.IsWhiteSpace |> Seq.length |> Some
                 else
                     None)

--- a/src/Common/StringParsing.fs
+++ b/src/Common/StringParsing.fs
@@ -108,8 +108,11 @@ module String =
     let removeSpaces (lines: string list) =
         let spaces =
             lines
-            |> Seq.filter (String.IsNullOrWhiteSpace >> not)
-            |> Seq.map (fun line -> line |> Seq.takeWhile Char.IsWhiteSpace |> Seq.length)
+            |> Seq.choose (fun line ->
+                if not <| String.IsNullOrWhiteSpace line then
+                    line |> Seq.takeWhile Char.IsWhiteSpace |> Seq.length |> Some
+                else
+                    None)
             |> fun xs -> if Seq.isEmpty xs then 0 else Seq.min xs
 
         lines

--- a/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
+++ b/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
@@ -2264,8 +2264,11 @@ module internal SymbolReader =
         do
             replacedParagraphs
             |> Seq.collect collectParagraphIndirectLinks
-            |> Seq.filter (linkNotDefined doc)
-            |> Seq.map (getTypeLink ctx)
+            |> Seq.choose (fun line ->
+                if linkNotDefined doc line then
+                    getTypeLink ctx line |> Some
+                else
+                    None)
             |> Seq.iter (addLinkToType doc)
 
         doc.With(paragraphs = replacedParagraphs)

--- a/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
+++ b/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
@@ -2265,10 +2265,8 @@ module internal SymbolReader =
             replacedParagraphs
             |> Seq.collect collectParagraphIndirectLinks
             |> Seq.choose (fun line ->
-                if linkNotDefined doc line then
-                    getTypeLink ctx line |> Some
-                else
-                    None)
+                let linkIsDefined = linkNotDefined doc line |> not
+                if linkIsDefined then None else getTypeLink ctx line |> Some)
             |> Seq.iter (addLinkToType doc)
 
         doc.With(paragraphs = replacedParagraphs)

--- a/src/FSharp.Formatting.Common/Templating.fs
+++ b/src/FSharp.Formatting.Common/Templating.fs
@@ -48,10 +48,15 @@ type FrontMatterFile =
                 // Allow empty lines in frontmatter
                 let isBlankLine = String.IsNullOrWhiteSpace line
                 isBlankLine || line.Contains(":"))
-            |> Seq.filter (String.IsNullOrWhiteSpace >> not)
-            |> Seq.map (fun line ->
-                let parts = line.Split(":")
-                parts.[0].ToLowerInvariant(), parts.[1])
+            |> Seq.choose (fun line ->
+                let parts = line.Split(":") |> Array.toList
+
+                if not <| String.IsNullOrWhiteSpace line then
+                    match parts with
+                    | first :: second :: _ -> Some(first.ToLowerInvariant(), second)
+                    | _ -> None
+                else
+                    None)
             |> Map.ofSeq
 
         match

--- a/src/FSharp.Formatting.Common/Templating.fs
+++ b/src/FSharp.Formatting.Common/Templating.fs
@@ -49,9 +49,9 @@ type FrontMatterFile =
                 let isBlankLine = String.IsNullOrWhiteSpace line
                 isBlankLine || line.Contains(":"))
             |> Seq.choose (fun line ->
-                let parts = line.Split(":") |> Array.toList
+                if String.IsNullOrWhiteSpace line |> not then
+                    let parts = line.Split(":") |> Array.toList
 
-                if not <| String.IsNullOrWhiteSpace line then
                     match parts with
                     | first :: second :: _ -> Some(first.ToLowerInvariant(), second)
                     | _ -> None

--- a/src/FSharp.Formatting.Common/YaafFSharpScripting.fs
+++ b/src/FSharp.Formatting.Common/YaafFSharpScripting.fs
@@ -83,7 +83,6 @@ module internal CompilerServiceExtensions =
 
                  options.OtherOptions
                  |> Array.filter (fun path -> path.StartsWith("-r:", StringComparison.Ordinal))
-                 |> Array.filter (fun path -> path.StartsWith("-r:", StringComparison.Ordinal))
                  //|> Seq.choose (fun path -> if path.StartsWith "-r:" then path.Substring 3 |> Some else None)
                  //|> Seq.map (fun path -> path.Replace("\\\\", "\\"))
                  |> Array.toList)
@@ -180,11 +179,11 @@ module internal CompilerServiceExtensions =
                 || libDirs
                    |> List.exists (fun lib ->
                        Directory.EnumerateFiles(lib)
-                       |> Seq.filter (fun file -> Path.GetExtension file =? ".dll")
                        |> Seq.filter (fun file ->
                            // If we find a FSharp.Core in a lib path, we check if is suited for us...
-                           Path.GetFileNameWithoutExtension file <>? "FSharp.Core"
-                           || (tryCheckFsCore file |> Option.isSome))
+                           Path.GetExtension file =? ".dll"
+                           && (Path.GetFileNameWithoutExtension file <>? "FSharp.Core"
+                               || (tryCheckFsCore file |> Option.isSome)))
                        |> Seq.toList
                        |> isAssembly asm)
 
@@ -279,10 +278,9 @@ module internal CompilerServiceExtensions =
 
             let findReferences libDir =
                 Directory.EnumerateFiles(libDir, "*.dll")
-                |> Seq.map Path.GetFullPath
                 // Filter files already referenced directly
                 |> Seq.filter (fun file ->
-                    let fileName = Path.GetFileName file
+                    let fileName = Path.GetFullPath file |> Path.GetFileName
 
                     dllFiles
                     |> List.exists (fun (dllFile: string) -> Path.GetFileName dllFile =? fileName)

--- a/src/fsdocs-tool/BuildCommand.fs
+++ b/src/fsdocs-tool/BuildCommand.fs
@@ -95,9 +95,12 @@ type internal DocContent
         (subFolderFullPath = rootOutputFolderFullPath)
 
     let allCultures =
-        System.Globalization.CultureInfo.GetCultures(System.Globalization.CultureTypes.AllCultures)
-        |> Array.map (fun x -> x.TwoLetterISOLanguageName)
-        |> Array.filter (fun x -> x.Length = 2)
+        CultureInfo.GetCultures(CultureTypes.AllCultures)
+        |> Array.choose (fun x ->
+            if x.TwoLetterISOLanguageName.Length <> 2 then
+                None
+            else
+                Some x.TwoLetterISOLanguageName)
         |> Array.distinct
 
     let makeMarkdownLinkResolver


### PR DESCRIPTION
I was poking around the repo and saw these few spots where I thought we could get some minor performance gains. There are also quite a few areas where we have multiple `Seq.Filter`'s next to each other. I would also like to suggest updating those unless maintainers know of a reason why we have multiple filter iterations next to each other. Hope this helps!
