### PR TITLE
Improve API doc content alignment

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 21.0.0-beta-002 - 2024-06-19
+
+### Changed
+* Shrink API docs example heading font size a bit.
+* Improve overall API doc content alignment consistency in various scenarios.
+
 ## 21.0.0-beta-001 - 2024-06-06
 
 ### Added

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,8 +3,8 @@
 ## 21.0.0-beta-002 - 2024-06-19
 
 ### Changed
-* Shrink API docs example heading font size a bit.
-* Improve overall API doc content alignment consistency in various scenarios.
+* Shrink API docs example heading font size a bit. [#923](https://github.com/fsprojects/FSharp.Formatting/pull/923)
+* Improve overall API doc content alignment consistency in various scenarios. [#923](https://github.com/fsprojects/FSharp.Formatting/pull/923)
 
 ## 21.0.0-beta-001 - 2024-06-06
 

--- a/docs/content/fsdocs-default.css
+++ b/docs/content/fsdocs-default.css
@@ -1088,8 +1088,7 @@ span[onmouseout] {
             margin: var(--spacing-200) 0 var(--spacing-200) var(--spacing-300);
 
             &:first-child:is(.icon-button-row) {
-                margin-top: 0;
-                margin-bottom: 0;
+                margin-block: 0;
             }
 
             &:nth-child(2) {
@@ -1146,8 +1145,7 @@ span[onmouseout] {
             margin: var(--spacing-200) 0 var(--spacing-200) var(--spacing-300);
 
             &:is(summary) {
-                margin-top: 0;
-                margin-bottom: 0;
+                margin-block: 0;
             }
 
             &:first-child {

--- a/docs/content/fsdocs-default.css
+++ b/docs/content/fsdocs-default.css
@@ -1083,6 +1083,23 @@ span[onmouseout] {
         display: flex;
         flex-direction: column;
         justify-content: flex-start;
+
+        > * {
+            margin: var(--spacing-200) 0 var(--spacing-200) var(--spacing-300);
+
+            &:first-child:is(.icon-button-row) {
+                margin-top: 0;
+                margin-bottom: 0;
+            }
+
+            &:nth-child(2) {
+                margin-top: 0;
+            }
+
+            &:last-child {
+                margin-bottom: 0;
+            }
+        }
     }
 
     .icon-button-row {
@@ -1099,8 +1116,6 @@ span[onmouseout] {
             counter-increment: list-item 0;
             list-style: disclosure-closed outside;
             cursor: pointer;
-            width: calc(100% - var(--spacing-300));
-            margin-left: var(--spacing-300);
 
             > .fsdocs-summary {
                 display: flex;
@@ -1127,8 +1142,13 @@ span[onmouseout] {
             margin-bottom: var(--spacing-200);
         }
 
-        .fsdocs-returns, .fsdocs-params, .fsdocs-example-header, pre.fssnip.highlighted {
+        & details > * {
             margin: var(--spacing-200) 0 var(--spacing-200) var(--spacing-300);
+
+            &:is(summary) {
+                margin-top: 0;
+                margin-bottom: 0;
+            }
 
             &:first-child {
                 margin-top: 0;

--- a/docs/content/fsdocs-default.css
+++ b/docs/content/fsdocs-default.css
@@ -1127,7 +1127,7 @@ span[onmouseout] {
             margin-bottom: var(--spacing-200);
         }
 
-        .fsdocs-returns, .fsdocs-params {
+        .fsdocs-returns, .fsdocs-params, .fsdocs-example-header, pre.fssnip.highlighted {
             margin: var(--spacing-200) 0 var(--spacing-200) var(--spacing-300);
 
             &:first-child {
@@ -1145,6 +1145,10 @@ span[onmouseout] {
 
         .fsdocs-param-docs p {
             margin: var(--spacing-200) 0;
+        }
+
+        .fsdocs-example-header {
+            font-size: var(--font-200);
         }
 
         > div.fsdocs-summary {


### PR DESCRIPTION
- Shrink the example heading font size a bit.
- Align the example with the rest of the summary/details.
- Improve overall API doc content alignment consistency.

#### Before & after

https://github.com/fsprojects/FSharp.Formatting/assets/14795984/45a991c2-f3a8-4e8c-81a2-fff213247dbd

https://github.com/fsprojects/FSharp.Formatting/assets/14795984/4dd175f0-b0c7-417b-b638-dd658e77986c

