### PR TITLE
Remove root parameter override in watch mode

### DIFF
--- a/src/fsdocs-tool/BuildCommand.fs
+++ b/src/fsdocs-tool/BuildCommand.fs
@@ -1405,24 +1405,12 @@ type CoreBuildOptions(watch) =
 
         // Adjust the user substitutions for 'watch' mode root
         let userRoot, userParameters =
-            if watch then
-                let userRoot = sprintf "http://localhost:%d/" this.port_option
+            let r =
+                match userParametersDict.TryGetValue(ParamKeys.root) with
+                | true, v -> Some v
+                | _ -> None
 
-                if userParametersDict.ContainsKey(ParamKeys.root) then
-                    printfn "ignoring user-specified root since in watch mode, root = %s" userRoot
-
-                let userParameters =
-                    [ ParamKeys.root, userRoot ]
-                    @ (userParameters |> List.filter (fun (a, _) -> a <> ParamKeys.root))
-
-                Some userRoot, userParameters
-            else
-                let r =
-                    match userParametersDict.TryGetValue(ParamKeys.root) with
-                    | true, v -> Some v
-                    | _ -> None
-
-                r, userParameters
+            r, userParameters
 
         let userCollectionName =
             match (dict userParameters).TryGetValue(ParamKeys.``fsdocs-collection-name``) with


### PR DESCRIPTION
## Summary
- Remove `if watch` branch when setting `userRoot`

## Description
Re: #924 , it seems this behavior is specifically intended. I'm sure there are other associated changes that this would need. Would love pointers on where to go from here.