### PR TITLE
Update FSharp.Core and FSharp.Compiler.Service dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,8 +6,8 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- locking the version of F# Core as FCS does this anyway and in practise all will be using the same version -->
-    <PackageVersion Include="FSharp.Core" Version="[8.0.100]" />
-    <PackageVersion Include="FSharp.Compiler.Service" Version="[43.8.100]" />
+    <PackageVersion Include="FSharp.Core" Version="[8.0.301]" />
+    <PackageVersion Include="FSharp.Compiler.Service" Version="[43.8.301]" />
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <PackageVersion Include="Microsoft.Build" Version="" PrivateAssets="all" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="" PrivateAssets="all" />

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,9 @@
 # Changelog
 
 ## 21.0.0-beta-003 - 2024-08-06
-* FSharp.Core and FSharp.Compiler.Service updates. [#935](https://github.com/fsprojects/FSharp.Formatting/pull/935)
+
+### Changed
+* Update FCS to 43.8.301. [#935](https://github.com/fsprojects/FSharp.Formatting/pull/935)
 
 ## 21.0.0-beta-002 - 2024-06-19
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 21.0.0-beta-003 - 2024-08-06
+* FSharp.Core and FSharp.Compiler.Service updates. [#935](https://github.com/fsprojects/FSharp.Formatting/pull/935)
+
 ## 21.0.0-beta-002 - 2024-06-19
 
 ### Changed


### PR DESCRIPTION
Temporary fix #934 to get the system to work with latest stable FSharp.Core until further decisions are considered.
