### PR TITLE
Add CSS Classes to Built-In Menu Items

### DIFF
--- a/docs/_template.html
+++ b/docs/_template.html
@@ -37,12 +37,12 @@
             <input type="checkbox" name="mobile-menu" />
             <ul class="menu">
                 <li class="nav-header">Links</li>
-                <li class="nav-item"><a class="nav-link" href="{{fsdocs-license-link}}">License</a>
+                <li class="license-menu-item builtin-menu-item nav-item"><a class="nav-link" href="{{fsdocs-license-link}}">License</a>
                 </li>
-                <li class="nav-item"><a class="nav-link"
+                <li class="license-menu-item builtin-menu-item nav-item"><a class="nav-link"
                                         href="{{fsdocs-release-notes-link}}">Release
                     Notes</a></li>
-                <li class="nav-item"><a class="nav-link" href="{{fsdocs-repository-link}}">Source
+                <li class="repository-menu-item builtin-menu-item nav-item"><a class="nav-link" href="{{fsdocs-repository-link}}">Source
                     Repository</a></li>
                 {{fsdocs-list-of-documents}}
                 {{fsdocs-list-of-namespaces}}
@@ -64,12 +64,12 @@
 <aside id="fsdocs-main-menu">
     <ul class="menu">
         <li class="nav-header">Links</li>
-        <li class="nav-item"><a class="nav-link" href="{{fsdocs-license-link}}">License</a>
+        <li class="license-menu-item builtin-menu-item nav-item"><a class="nav-link" href="{{fsdocs-license-link}}">License</a>
         </li>
-        <li class="nav-item"><a class="nav-link"
+        <li class="release-notes-menu-item builtin-menu-item nav-item"><a class="nav-link"
                                 href="{{fsdocs-release-notes-link}}">Release
             Notes</a></li>
-        <li class="nav-item"><a class="nav-link" href="{{fsdocs-repository-link}}">Source
+        <li class="repository-menu-item builtin-menu-item nav-item"><a class="nav-link" href="{{fsdocs-repository-link}}">Source
             Repository</a></li>
         {{fsdocs-list-of-documents}}
         {{fsdocs-list-of-namespaces}}

--- a/docs/_template.html
+++ b/docs/_template.html
@@ -39,7 +39,7 @@
                 <li class="nav-header">Links</li>
                 <li class="license-menu-item builtin-menu-item nav-item"><a class="nav-link" href="{{fsdocs-license-link}}">License</a>
                 </li>
-                <li class="license-menu-item builtin-menu-item nav-item"><a class="nav-link"
+                <li class="release-notes-menu-item builtin-menu-item nav-item"><a class="nav-link"
                                         href="{{fsdocs-release-notes-link}}">Release
                     Notes</a></li>
                 <li class="repository-menu-item builtin-menu-item nav-item"><a class="nav-link" href="{{fsdocs-repository-link}}">Source


### PR DESCRIPTION
I'm using FSDocs for an internal company project and we don't have licenses for our private repos. I added CSS classes to all the built-in menu items so they can be hidden with CSS.
