### PR TITLE
fix: remove duplicated `Type Extensions`

### DIFF
--- a/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
+++ b/src/FSharp.Formatting.ApiDocs/GenerateModel.fs
@@ -2737,6 +2737,11 @@ module internal SymbolReader =
             let exts, nsdocs2 =
                 readMembers ctx entityUrl ApiDocMemberKind.TypeExtension modul (fun v -> v.IsExtensionMember)
 
+            // `with get and set` syntax is sugar for a mutable field, a get binding and a set binding
+            // This result in duplicated Method Extensions, we use DeclarationLocation to keep only one
+            // See https://github.com/fsprojects/FSharp.Formatting/issues/941
+            let exts = exts |> List.distinctBy (fun m -> m.Symbol.DeclarationLocation)
+
             let pats, nsdocs3 =
                 readMembers ctx entityUrl ApiDocMemberKind.ActivePattern modul (fun v -> v.IsActivePattern)
 


### PR DESCRIPTION
Fix #941

It seems like they all have the same `DeclarationLocation` which can make sense if this is just syntax sugar.