### PR TITLE
update readme dev instructions to use net8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ See https://fsprojects.github.io/FSharp.Formatting/
 Once built, you can run the command-line tool to self-build the docs for this directory using 
 
     dotnet build
-    src\fsdocs-tool\bin\Debug\net6.0\fsdocs.exe watch
-    src\fsdocs-tool\bin\Debug\net6.0\fsdocs.exe build --clean
+    src\fsdocs-tool\bin\Debug\net8.0\fsdocs.exe watch
+    src\fsdocs-tool\bin\Debug\net8.0\fsdocs.exe build --clean
 
 ### Pipelines
 


### PR DESCRIPTION
update readme dev instructions to use net8.0 so that when you copy and paste into terminal it'll use the right binary for the fsdocs tool.