### PR TITLE
fix: correct matchMedia query in theme toggle

### DIFF
--- a/docs/content/fsdocs-theme-toggle.js
+++ b/docs/content/fsdocs-theme-toggle.js
@@ -1,6 +1,6 @@
 ﻿import {LitElement, html, css} from 'https://cdn.jsdelivr.net/gh/lit/dist@3/core/lit-core.min.js';
 
-const prefersDark = window.matchMedia("@media (prefers-color-scheme: dark)").matches;
+const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
 let currentTheme = localStorage.getItem('theme') ?? (prefersDark ? 'dark' : 'light');
 
 export class ThemeToggle extends LitElement {


### PR DESCRIPTION
The "@media" prefix is invalid inside matchMedia() — it takes a bare media query string. This caused prefersDark to always be false, so the toggle icon defaulted to the light theme regardless of OS preference.
