### PR TITLE
[Repo Assist] Remove duplicate CI trigger on push to main

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -1,9 +1,6 @@
 name: Build and Test PR
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
     - main


### PR DESCRIPTION
The 'Build and Test PR' workflow was triggered on both 'pull_request'
and 'push: main'. This caused duplicate CI runs every time a PR was
merged: both pull-requests.yml (Ubuntu + Windows) and push-main.yml
(Ubuntu) would run the full pipeline in parallel.

The push-main.yml workflow already handles all post-merge work on main
(lint, build, test, pack, generate docs, deploy, publish NuGet).
The PR workflow's purpose is cross-platform testing *before* merge.
Removing the 'push: main' trigger eliminates ~2 redundant jobs per merge.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
