### PR TITLE
[Repo Assist] ci: upload TRX test results as artifacts on CI failure

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -43,7 +43,15 @@ jobs:
       uses: actions/setup-dotnet@v5
     - name: Run CI
       run: dotnet fsi build.fsx
-  
+
+    - name: Upload test results
+      uses: actions/upload-artifact@v4
+      if: failure()
+      with:
+        name: test-results-${{ matrix.os }}
+        path: TestResults/
+        retention-days: 7
+
     - name: Analyze Solution
       if: matrix.os == 'ubuntu-latest'
       run: dotnet msbuild /t:AnalyzeSolution

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -41,6 +41,15 @@ jobs:
       uses: actions/setup-dotnet@v5
     - name: Run CI
       run: dotnet fsi build.fsx
+
+    - name: Upload test results
+      uses: actions/upload-artifact@v4
+      if: failure()
+      with:
+        name: test-results-ubuntu
+        path: TestResults/
+        retention-days: 7
+
     - name: Deploy docs
       uses: peaceiris/actions-gh-pages@v4
       with:


### PR DESCRIPTION
When `dotnet fsi build.fsx` fails (e.g. due to test failures), the
.trx and blame files in TestResults/ are now uploaded as a GitHub Actions
artifact (retained for 7 days).  This makes it much easier to diagnose
test failures without re-running the full CI pipeline locally.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
