### PR TITLE
Document agentic contribution workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,32 @@
+# Contributing to FSharp.Formatting
+
+FSharp.Formatting is primarily maintained through agentic development under human guidance.
+Maintainers discuss proposed work and then direct coding agents to make the complete change,
+including implementation, tests, documentation, samples, and other affected files.
+
+## Start With an Issue
+
+We generally prefer contributions as [GitHub issues] rather than pull requests. Search for an
+existing report first. Issues may include proposed changes, patches, or links to forks or branches.
+Maintainers may refine the scope and assign the issue to an agent to implement and validate the
+complete change.
+
+## Repo Assist
+
+[Repo Assist] is an automated AI assistant that runs regularly in this repository. It may triage or
+respond to issues, investigate bugs, suggest improvements, and attempt implementations as draft pull
+requests. Its work is identified as automated and remains subject to human review; Repo Assist does
+not merge pull requests or make final maintenance decisions.
+
+Maintainers can invoke Repo Assist with `/repo-assist <instructions>` for a specific agentic task,
+such as investigating an issue, preparing a fix, adding tests, or updating documentation.
+
+## Pull Requests
+
+Every pull request must have a matching issue that has been discussed with the maintainers. Link the
+pull request to that issue and keep it focused. Maintainers may close a pull request and use the issue
+as the basis for an agent-produced implementation instead; the submitted analysis and code remain
+valuable inputs to that work.
 
 ## Building and Development
 
@@ -14,3 +43,6 @@ Run
     dotnet fantomas src tests docs build.fsx -r
 
 to format the code you've written.
+
+[GitHub issues]: https://github.com/fsprojects/FSharp.Formatting/issues
+[Repo Assist]: https://github.com/githubnext/agentics/blob/main/docs/repo-assist.md


### PR DESCRIPTION
## Summary

- prefer issues for human-guided agentic maintenance
- require pull requests to have a matching, discussed issue
- document scheduled and maintainer-directed Repo Assist tasks
- preserve repository-specific contribution and validation guidance

Closes #1265.

## Validation

- `git diff --check -- CONTRIBUTING.md`