### PR TITLE
[repo-assist] deps: bump Ionide.ProjInfo to 0.75.0 and NUnit3TestAdapter to 6.3.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="Microsoft.Build.Framework" Version="" PrivateAssets="all" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="" PrivateAssets="all" />
     <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="" PrivateAssets="all" />
-    <PackageVersion Include="Ionide.ProjInfo" Version="0.74.2" />
+    <PackageVersion Include="Ionide.ProjInfo" Version="0.75.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="Suave" Version="3.4.6" />
     <PackageVersion Include="System.Memory" Version="4.6.3" />
@@ -22,7 +22,7 @@
     <PackageVersion Include="NUnit" Version="4.6.0" />
     <PackageVersion Include="FsUnit" Version="7.1.1" />
     <PackageVersion Include="FSharp.Data" Version="8.1.14" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="6.3.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="Ionide.KeepAChangelog.Tasks" Version="0.3.3" />
     <PackageVersion Include="G-Research.FSharp.Analyzers" Version="0.22.0" />

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Changed
+* Bump `Ionide.ProjInfo` from 0.74.2 to 0.75.0 and `NUnit3TestAdapter` from 6.2.0 to 6.3.0. Both are routine, non-breaking updates.
 * Rewrote the Mermaid documentation recipe as `docs/mermaid.md` (moved from the oddly-named `docs/sidebyside/sidemermaid.md`) to follow the approach used by the fantomas docs: diagrams are written as plain ```mermaid fenced code blocks, which GitHub renders natively, and an `_body.html` script promotes those blocks into `<div class="mermaid">` elements on fsdocs pages. The FSharp.Formatting docs now ship that script (`docs/_body.html`), so the recipe page actually demonstrates working diagrams.
 
 ## [22.2.0] - 2026-08-31


### PR DESCRIPTION
🤖 *This PR was created by Repo Assist, an automated AI assistant.*

## Summary

Bundles two small dependency updates originally proposed by Dependabot:

- Ionide.ProjInfo 0.74.2 → 0.75.0 (#1273)
- NUnit3TestAdapter 6.2.0 → 6.3.0 (#1268)

This manually applies the protected-file patch from #1283 (also superseding the duplicate attempt in #1276).

Closes #1283
Closes #1276

## Test Status

- ✅ `dotnet restore FSharp.Formatting.sln`
- ✅ `dotnet build FSharp.Formatting.sln --configuration Release` (0 warnings, 0 errors)
- ✅ `dotnet test tests/fsdocs-tool.Tests/fsdocs-tool.Tests.fsproj --configuration Release --no-build`
- ✅ `dotnet test tests/FSharp.Markdown.Tests/FSharp.Markdown.Tests.fsproj --configuration Release --no-build`

## Trade-offs

The change is limited to central package versions and the Unreleased release notes. Maintainers can close #1273 and #1268 after merge.