### PR TITLE
Bump all dotnet packages.

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,14 +3,14 @@
   "isRoot": true,
   "tools": {
     "fantomas": {
-      "version": "8.0.0-beta-001",
+      "version": "8.0.0-beta-002",
       "commands": [
         "fantomas"
       ],
       "rollForward": false
     },
     "fsharp-analyzers": {
-      "version": "0.36.0",
+      "version": "0.38.0",
       "commands": [
         "fsharp-analyzers"
       ],

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,12 @@ updates:
   - dependency-name: "Microsoft.Build.Tasks.Core"
   open-pull-requests-limit: 25
   package-ecosystem: nuget
+  groups:
+    nuget:
+      patterns:
+      - "*"
   schedule:
-    interval: daily
+    interval: weekly
     time: "10:00"
 - allow:
   - dependency-name: "FSharp.Compiler.Service"

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,17 +17,17 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="Suave" Version="3.4.6" />
     <PackageVersion Include="FSharp.Data.Adaptive" Version="1.2.26" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.12" />
     <PackageVersion Include="System.Memory" Version="4.6.3" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.8" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.12" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
-    <PackageVersion Include="NUnit" Version="4.6.0" />
+    <PackageVersion Include="NUnit" Version="4.6.1" />
     <PackageVersion Include="FsUnit" Version="7.1.1" />
-    <PackageVersion Include="FSharp.Data" Version="8.1.14" />
+    <PackageVersion Include="FSharp.Data" Version="8.2.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.3.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.10.0" />
     <PackageVersion Include="Ionide.KeepAChangelog.Tasks" Version="0.3.3" />
-    <PackageVersion Include="G-Research.FSharp.Analyzers" Version="0.22.0" />
-    <PackageVersion Include="Ionide.Analyzers" Version="0.15.0" />
+    <PackageVersion Include="G-Research.FSharp.Analyzers" Version="0.24.0" />
+    <PackageVersion Include="Ionide.Analyzers" Version="0.18.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
We got a lot of PRs (and thus noise) for minor NuGet updates.
I did them all together and enabled grouping in Dependabot so this happens in a similar way going forward.

FYI @dsyme 