### PR TITLE
Follow #load and local #r dependencies in fsdocs watch

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## [Unreleased]
+## [23.0.0-alpha.2] - 2026-09-10
 
 ### Fixed
 * Fix tooltip not being interactive: moving the mouse from a code token into its tooltip now keeps the tooltip open, allowing users to select and copy the tooltip text. [#949](https://github.com/fsprojects/FSharp.Formatting/issues/949)
+* `fsdocs watch` rebuilds a page when a file its script depends on changes, following `#load` transitively and `#r` to local files, wherever those files are (a dot folder, outside the input folder). The directives are read from the syntax tree, so a `#load` in a comment does not count. [#1309](https://github.com/fsprojects/FSharp.Formatting/issues/1309)
 
 ## [23.0.0-alpha.1] - 2026-09-08
 

--- a/src/fsdocs-tool/DevServer.fs
+++ b/src/fsdocs-tool/DevServer.fs
@@ -599,7 +599,6 @@ type internal ContentMeta =
     {
         FrontMatter: ScannedFrontMatter
         FrontMatterFile: FrontMatterFile option
-        Loads: string list
         UsesCref: bool
         Error: string option
     }
@@ -720,10 +719,20 @@ type internal Site(config: SiteConfig) =
         && rel.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
            |> Array.exists (fun s -> s.StartsWith '.')
 
+    /// A file of the input trees: under a root and not in a dot folder
+    let isTreeFile (path: string) =
+        treeRoots |> List.exists (fun r -> isUnder r path && not (isInDotFolder r path))
+
+    /// The files the scripts depend on through '#load' and '#r', discovered when a script is
+    /// refreshed. They are watched wherever they are: in a dot folder, outside the input trees.
+    /// Guarded by 'refreshLock'.
+    let loadTargets = System.Collections.Generic.HashSet<string>()
+
     let isWatchedFile (path: string) =
         dllSet.Contains path
         || projectSet.Contains path
-        || treeRoots |> List.exists (fun r -> isUnder r path && not (isInDotFolder r path))
+        || loadTargets.Contains path
+        || isTreeFile path
 
     let isMenuTemplate (path: string) =
         let name = Path.GetFileName path
@@ -742,6 +751,7 @@ type internal Site(config: SiteConfig) =
         || isMenuTemplate path
         || dllSet.Contains path
         || projectSet.Contains path
+        || loadTargets.Contains path
 
     // ---------------------------------------------------------------------------------------------
     // Inputs of the graph and the change pipeline
@@ -749,6 +759,8 @@ type internal Site(config: SiteConfig) =
     let files = cmap<string, FileStamp>()
     let dlls = cmap<string, FileStamp>()
     let projects = cmap<string, FileStamp>()
+    /// The files each script depends on through its hash directives, kept in step with 'files'
+    let scriptLoads = cmap<string, string list>()
     let lastStat = Dictionary<string, struct (int64 * DateTime)>()
     let knownHash = Dictionary<string, string>()
     let refreshLock = obj ()
@@ -792,10 +804,18 @@ type internal Site(config: SiteConfig) =
             while events.Count > 200 do
                 events.TryDequeue() |> ignore
 
-    let hashFile (path: string) =
-        use stream = File.OpenRead path
-        use sha = SHA256.Create()
-        sha.ComputeHash stream |> Convert.ToHexString
+    let hashBytes (bytes: byte array) =
+        SHA256.HashData bytes |> Convert.ToHexString
+
+    let hashFile (path: string) = File.ReadAllBytes path |> hashBytes
+
+    /// Whether the hash directives of this file feed the graph: a content script or a loaded one
+    let hasDirectives (path: string) =
+        Content.isFsxFile path && (isTreeFile path || loadTargets.Contains path)
+
+    let textOf (bytes: byte array) =
+        use reader = new StreamReader(new MemoryStream(bytes), Encoding.UTF8, true)
+        reader.ReadToEnd()
 
     let tryStat (path: string) =
         let fi = FileInfo path
@@ -847,7 +867,11 @@ type internal Site(config: SiteConfig) =
                 | None ->
                     if lastStat.Remove path then
                         knownHash.Remove path |> ignore
-                        transact (fun () -> map.Remove path |> ignore)
+
+                        transact (fun () ->
+                            map.Remove path |> ignore
+                            scriptLoads.Remove path |> ignore)
+
                         logger.Debugf "deleted %s: invalidated" path
                         recordEvent path "deleted" true
                         true
@@ -860,20 +884,21 @@ type internal Site(config: SiteConfig) =
                     | true, previous when previous = stat && (cause = Reconciliation || not (contentMatters path)) ->
                         false
                     | _ ->
-                        let hashResult =
+                        let readResult =
                             if contentMatters path then
                                 try
-                                    Result.Ok(hashFile path)
+                                    let bytes = File.ReadAllBytes path
+                                    Result.Ok(hashBytes bytes, bytes)
                                 with ex ->
                                     Result.Error ex
                             else
-                                Result.Ok ""
+                                Result.Ok("", [||])
 
-                        match hashResult with
+                        match readResult with
                         | Result.Error _ ->
                             // Mid-write or locked: leave the stat alone so the reconciler retries
                             false
-                        | Result.Ok hash ->
+                        | Result.Ok(hash, bytes) ->
                             lastStat.[path] <- stat
 
                             match knownHash.TryGetValue path with
@@ -884,17 +909,33 @@ type internal Site(config: SiteConfig) =
                             | _ ->
                                 knownHash.[path] <- hash
 
+                                let loads =
+                                    if hasDirectives path then
+                                        ScriptDirectives.dependenciesOf path (textOf bytes)
+                                    else
+                                        []
+
                                 transact (fun () ->
                                     map.[path] <-
                                         {
                                             Length = length
                                             LastWriteUtc = lastWrite
                                             Hash = hash
-                                        })
+                                        }
+
+                                    if hasDirectives path then
+                                        scriptLoads.[path] <- loads)
 
                                 logger.Debugf "%s %s: invalidated" change path
                                 recordEvent path change true
                                 changedFiles.Trigger path
+
+                                // Files this script depends on for the first time enter the graph now
+                                for load in loads do
+                                    if loadTargets.Add load then
+                                        logger.Debugf "%s depends on %s" path load
+                                        refresh cause "discovered" load |> ignore
+
                                 true)
 
     /// Forget the current bytes of a file the site rewrote itself (notebook evaluation), so the
@@ -927,6 +968,9 @@ type internal Site(config: SiteConfig) =
             for project in projectPaths do
                 if File.Exists project then
                     yield project
+            for target in loadTargets do
+                if File.Exists target then
+                    yield target
         ]
 
     /// Compare the watched roots with the last snapshot and refresh every difference.
@@ -943,19 +987,6 @@ type internal Site(config: SiteConfig) =
     // ---------------------------------------------------------------------------------------------
     // Derived nodes
 
-    let loadRegex = Regex(@"^\s*#load\s+(.*)$", RegexOptions.Multiline)
-    let quotedRegex = Regex("\"([^\"]+)\"")
-
-    let loadsOf (path: string) (text: string) =
-        if Content.isFsxFile path then
-            [
-                for m in loadRegex.Matches text do
-                    for q in quotedRegex.Matches m.Groups.[1].Value do
-                        Path.GetFullPath(Path.Combine(Path.GetDirectoryName path, q.Groups.[1].Value))
-            ]
-        else
-            []
-
     let computeMeta (path: string) : ContentMeta =
         try
             let text = File.ReadAllText path
@@ -963,7 +994,6 @@ type internal Site(config: SiteConfig) =
             {
                 FrontMatter = Content.scanFrontMatter path
                 FrontMatterFile = Content.parseFrontMatterOfFile path
-                Loads = loadsOf path text
                 UsesCref = text.Contains "cref:"
                 Error = None
             }
@@ -978,7 +1008,6 @@ type internal Site(config: SiteConfig) =
                         Index = None
                     }
                 FrontMatterFile = None
-                Loads = []
                 UsesCref = true
                 Error = Some ex.Message
             }
@@ -1035,7 +1064,7 @@ type internal Site(config: SiteConfig) =
 
         for (root, rootAsGiven, outputRoot) in trees do
             for path in paths do
-                if isUnder root path then
+                if isUnder root path && not (isInDotFolder root path) then
                     let name = Path.GetFileName path
                     let folder = Path.GetDirectoryName path
                     let relFolder = Path.GetRelativePath(root, folder)
@@ -1257,7 +1286,7 @@ type internal Site(config: SiteConfig) =
 
     let contentMeta =
         files
-        |> AMap.filter (fun p _ -> Content.isContentFile p)
+        |> AMap.filter (fun p _ -> isTreeFile p && Content.isContentFile p)
         |> AMap.map (fun p _ -> computeMeta p)
 
     let metaList =
@@ -1296,18 +1325,33 @@ type internal Site(config: SiteConfig) =
     let headText = extraText "_head.html"
     let bodyText = extraText "_body.html"
 
+    /// The stamps of every file a script depends on, following '#load' transitively. 'visited'
+    /// holds the scripts on the current chain, so a load cycle ends.
+    let rec dependencyStamps (visited: Set<string>) (path: string) : aval<FileStamp option list> =
+        AMap.tryFind path scriptLoads
+        |> AVal.bind (fun loads ->
+            match loads with
+            | None -> AVal.constant []
+            | Some loads ->
+                loads
+                |> List.choose (fun load ->
+                    if visited.Contains load then
+                        None
+                    else
+                        AVal.map2
+                            (fun stamp deeper -> stamp :: deeper)
+                            (stampOf load)
+                            (dependencyStamps (visited.Add load) load)
+                        |> Some)
+                |> Adaptive.ofList
+                |> AVal.map List.concat)
+
     let pageModels = ConcurrentDictionary<ContentRoute, aval<LiterateDocModel>>()
 
     let makePageModel (route: ContentRoute) : aval<LiterateDocModel> =
         let path = route.InputFile
         let meta = AMap.tryFind path contentMeta
-
-        let loadStamps =
-            meta
-            |> AVal.bind (fun m ->
-                match m with
-                | Some m -> m.Loads |> List.map stampOf |> Adaptive.ofList
-                | None -> AVal.constant [])
+        let loadStamps = dependencyStamps (Set.singleton path) path
 
         let api =
             meta

--- a/src/fsdocs-tool/DevServer.fsi
+++ b/src/fsdocs-tool/DevServer.fsi
@@ -80,8 +80,6 @@ type internal ContentMeta =
         FrontMatter: ScannedFrontMatter
         /// The front matter used for next/previous links, present only when complete
         FrontMatterFile: FrontMatterFile option
-        /// Full paths of the files loaded with '#load'
-        Loads: string list
         /// Whether the file mentions 'cref:' and therefore needs the API model
         UsesCref: bool
         Error: string option

--- a/src/fsdocs-tool/ScriptDirectives.fs
+++ b/src/fsdocs-tool/ScriptDirectives.fs
@@ -1,0 +1,82 @@
+/// The files a script depends on through its hash directives.
+module fsdocs.ScriptDirectives
+
+open System.IO
+open FSharp.Compiler.CodeAnalysis
+open FSharp.Compiler.Syntax
+open FSharp.Compiler.Text
+
+/// A string argument, resolved against the folder of the script
+[<return: Struct>]
+let (|LocalPath|_|) (folder: string) (arg: ParsedHashDirectiveArgument) =
+    match arg with
+    | ParsedHashDirectiveArgument.String(value = value) ->
+        try
+            ValueSome(Path.GetFullPath(Path.Combine(folder, value)))
+        with _ ->
+            ValueNone
+    | _ -> ValueNone
+
+/// The files of a '#load', whether they exist or not
+[<return: Struct>]
+let (|Load|_|) (folder: string) (ParsedHashDirective(ident, args, _)) =
+    if ident <> "load" then
+        ValueNone
+    else
+        args
+        |> List.choose (function
+            | LocalPath folder file -> Some file
+            | _ -> None)
+        |> ValueSome
+
+/// The existing local files of a '#r': the other forms ('nuget:', assembly names) are not
+/// files the site can watch
+[<return: Struct>]
+let (|Reference|_|) (folder: string) (ParsedHashDirective(ident, args, _)) =
+    if ident <> "r" then
+        ValueNone
+    else
+        args
+        |> List.choose (function
+            | LocalPath folder file when File.Exists file -> Some file
+            | _ -> None)
+        |> ValueSome
+
+let dependenciesOf (path: string) (text: string) : string list =
+    let folder = Path.GetDirectoryName path
+
+    try
+        let parsed =
+            FSharp.Formatting.Internal.CompilerServiceExtensions.FSharpAssemblyHelper.checker.ParseFile(
+                path,
+                SourceText.ofString text,
+                { FSharpParsingOptions.Default with
+                    SourceFiles = [| path |]
+                    IsInteractive = true
+                }
+            )
+            |> Async.RunSynchronously
+
+        let directives =
+            match parsed.ParseTree with
+            | ParsedInput.SigFile _ -> []
+            | ParsedInput.ImplFile(ParsedImplFileInput(hashDirectives = directives; contents = modules)) ->
+                [
+                    yield! directives
+                    for SynModuleOrNamespace(decls = decls) in modules do
+                        for decl in decls do
+                            match decl with
+                            | SynModuleDecl.HashDirective(hashDirective = directive) -> yield directive
+                            | _ -> ()
+                ]
+
+        [
+            for directive in directives do
+                match directive with
+                | Load folder files
+                | Reference folder files -> yield! files
+                | _ -> ()
+        ]
+        |> List.distinct
+    with _ ->
+        []

--- a/src/fsdocs-tool/ScriptDirectives.fsi
+++ b/src/fsdocs-tool/ScriptDirectives.fsi
@@ -1,0 +1,8 @@
+/// The files a script depends on through its hash directives.
+module fsdocs.ScriptDirectives
+
+/// The full paths of the files loaded with '#load' and the local files referenced with '#r',
+/// from the syntax tree (comments and strings are not fooled). A '#load' target is returned
+/// whether it exists or not, a '#r' only when it names an existing file: the other forms
+/// ('nuget:', assembly names) are not files the site can watch.
+val dependenciesOf: path: string -> text: string -> string list

--- a/src/fsdocs-tool/fsdocs-tool.fsproj
+++ b/src/fsdocs-tool/fsdocs-tool.fsproj
@@ -23,6 +23,8 @@
     <Compile Include="DocContent.fs" />
     <Compile Include="LlmsTxt.fs" />
     <Compile Include="Diagnostics.fs" />
+    <Compile Include="ScriptDirectives.fsi" />
+    <Compile Include="ScriptDirectives.fs" />
     <Compile Include="DevServer.fsi" />
     <Compile Include="DevServer.fs" />
     <Compile Include="BuildCommand.fsi" />

--- a/tests/fsdocs-tool.Tests/SiteTests.fs
+++ b/tests/fsdocs-tool.Tests/SiteTests.fs
@@ -19,12 +19,15 @@ type internal Fixture() =
 
     let input = root </> "docs"
     let extras = root </> "extras"
+    let shared = root </> "shared"
     let project = root </> "Lib.fsproj"
 
     do
         Directory.CreateDirectory input |> ignore
         Directory.CreateDirectory(input </> "sub") |> ignore
+        Directory.CreateDirectory(input </> ".aux") |> ignore
         Directory.CreateDirectory extras |> ignore
+        Directory.CreateDirectory shared |> ignore
 
         File.WriteAllText(
             input </> "_template.html",
@@ -43,7 +46,16 @@ type internal Fixture() =
             "(**\n---\ncategory: Docs\ncategoryindex: 1\nindex: 2\n---\n*)\n#load \"lib.fsx\"\n(**\n# Page B\n*)\nlet y = Lib.x + 1\n"
         )
 
-        File.WriteAllText(input </> "lib.fsx", "module Lib\nlet x = 1\n")
+        // lib.fsx loads a script from a dot folder, which loads one outside the input, and
+        // references a local dll: none of them is a page, all of them influence b.fsx
+        File.WriteAllText(
+            input </> "lib.fsx",
+            "#load \"./.aux/common.fsx\"\n#r \"../shared/helper.dll\"\nlet x = Common.x + 1\n"
+        )
+
+        File.WriteAllText(input </> ".aux" </> "common.fsx", "#load \"../../shared/outside.fsx\"\nlet x = Outside.x\n")
+        File.WriteAllText(shared </> "outside.fsx", "let x = 1\n")
+        File.Copy(typeof<Fixture>.Assembly.Location, shared </> "helper.dll")
         File.WriteAllText(input </> "style.css", "body { }\n")
         File.WriteAllText(input </> ".hidden.md", "# Hidden\n")
         File.WriteAllText(input </> "sub" </> "c.md", "# Page C\n")
@@ -54,6 +66,7 @@ type internal Fixture() =
 
     member _.Input = input
     member _.Extras = extras
+    member _.Shared = shared
     member _.Project = project
 
     member _.Config: SiteConfig =
@@ -281,11 +294,60 @@ let ``pages are computed once and only invalidated by relevant changes`` () =
     body (site.Render "/b.html") |> shouldContainText "Page B"
     computedSince site [ "b.fsx" ]
     let lib = fx.Input </> "lib.fsx"
-    File.WriteAllText(lib, "module Lib\nlet x = 12\n")
+    let libText = File.ReadAllText lib
+    File.WriteAllText(lib, libText.Replace("+ 1", "+ 12"))
     site.Refresh lib |> shouldEqual true
     body (site.Render "/b.html") |> ignore
     computedSince site [ "b.fsx" ]
     body (site.Render "/index.html") |> ignore
+    computedSince site []
+
+    // ... transitively, through a dot folder the site does not serve
+    let common = fx.Input </> ".aux" </> "common.fsx"
+    File.WriteAllText(common, "#load \"../../shared/outside.fsx\"\nlet x = Outside.x + 1\n")
+    site.Refresh common |> shouldEqual true
+    body (site.Render "/b.html") |> ignore
+    computedSince site [ "b.fsx" ]
+    site.Resolve "/.aux/common.html" |> shouldEqual None
+
+    // ... and outside the input folder
+    let outside = fx.Shared </> "outside.fsx"
+    File.WriteAllText(outside, "let x = 2\n")
+    site.Refresh outside |> shouldEqual true
+    body (site.Render "/b.html") |> ignore
+    computedSince site [ "b.fsx" ]
+
+    // a local '#r' counts too
+    let helper = fx.Shared </> "helper.dll"
+    File.Copy(typeof<list<int>>.Assembly.Location, helper, true)
+    site.Refresh helper |> shouldEqual true
+    body (site.Render "/b.html") |> ignore
+    computedSince site [ "b.fsx" ]
+
+    // a '#load' added to a loaded script is followed, even before its target exists
+    File.WriteAllText(
+        common,
+        "#load \"../../shared/outside.fsx\"\n#load \"../../shared/more.fsx\"\nlet x = Outside.x + More.x\n"
+    )
+
+    site.Refresh common |> shouldEqual true
+    body (site.Render "/b.html") |> ignore
+    computedSince site [ "b.fsx" ]
+    let more = fx.Shared </> "more.fsx"
+    File.WriteAllText(more, "let x = 3\n")
+    site.Refresh more |> shouldEqual true
+    body (site.Render "/b.html") |> ignore
+    computedSince site [ "b.fsx" ]
+
+    // a comment mentioning '#load' is not a dependency
+    File.WriteAllText(lib, libText + "// #load \"../shared/nothing.fsx\"\n")
+    site.Refresh lib |> shouldEqual true
+    body (site.Render "/b.html") |> ignore
+    computedSince site [ "b.fsx" ]
+    let nothing = fx.Shared </> "nothing.fsx"
+    File.WriteAllText(nothing, "let x = 0\n")
+    site.Refresh nothing |> shouldEqual false
+    body (site.Render "/b.html") |> ignore
     computedSince site []
 
     // a template change re-renders without recomputing models


### PR DESCRIPTION
A page built from a script was only rebuilt when the script itself changed, not when a file it loads changed. The #load edge existed but came from a regex over the page and could only see files already in the watched set, which excludes dot folders and anything outside the input roots. The dotnet/fsharp release notes load a helper from a `.aux` folder, so its pages stayed stale until the script was edited (#1309).

The hash directives are now read from the syntax tree when a script is refreshed, so a `#load` in a comment does not count, and `#r` to an existing local file is tracked as well. Discovered files are watched wherever they live, hashed like content, walked by the reconciler and kept out of the routes when they sit in a dot folder. The page model follows the loads transitively through a new adaptive map of script dependencies, which replaces the `Loads` field of the content meta.

Fixes #1309 